### PR TITLE
Fixes #3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,9 +47,9 @@
 			<version>2.3.0</version>
 		</dependency>
 		<dependency>
-			<groupId>commons-lang</groupId>
-			<artifactId>commons-lang</artifactId>
-			<version>2.2</version>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-lang3</artifactId>
+			<version>3.9</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-io</groupId>

--- a/src/main/java/fvarrui/maven/plugin/javapackager/Main.java
+++ b/src/main/java/fvarrui/maven/plugin/javapackager/Main.java
@@ -1,6 +1,6 @@
 package fvarrui.maven.plugin.javapackager;
 
-import org.apache.commons.lang.SystemUtils;
+import org.apache.commons.lang3.SystemUtils;
 
 public class Main {
 

--- a/src/main/java/fvarrui/maven/plugin/javapackager/PackageMojo.java
+++ b/src/main/java/fvarrui/maven/plugin/javapackager/PackageMojo.java
@@ -17,7 +17,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.lang.SystemUtils;
+import org.apache.commons.lang3.SystemUtils;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.BuildPluginManager;

--- a/src/main/java/fvarrui/maven/plugin/javapackager/utils/FileUtils.java
+++ b/src/main/java/fvarrui/maven/plugin/javapackager/utils/FileUtils.java
@@ -16,7 +16,7 @@ import java.io.InputStream;
 import java.nio.file.Files;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.plugin.MojoExecutionException;
 
 

--- a/src/main/java/fvarrui/maven/plugin/javapackager/utils/JavaUtils.java
+++ b/src/main/java/fvarrui/maven/plugin/javapackager/utils/JavaUtils.java
@@ -4,7 +4,7 @@ public class JavaUtils {
 	
 	public static int getJavaMajorVersion() {
 		String version = System.getProperty("java.version");
-		return Integer.parseInt(version.substring(0, version.indexOf(".")));
+		return Integer.parseInt(version.split("\\.")[0]);
 	}
 
 }

--- a/src/main/java/fvarrui/maven/plugin/javapackager/utils/ProcessUtils.java
+++ b/src/main/java/fvarrui/maven/plugin/javapackager/utils/ProcessUtils.java
@@ -8,7 +8,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.codehaus.plexus.util.cli.CommandLineException;
 import org.codehaus.plexus.util.cli.Commandline;


### PR DESCRIPTION
In case you're wondering, in JavaUtils, line 7, I changed from `substring` to `split` for the same reason commons-lang was crashing with JDK 13