### PR TITLE
Fixes #7 and solves #8 and #9

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,22 +64,24 @@ And the following `plugin` tag to your `pom.xml`.
 
 Where:
 
-| Property                | Mandatory | Default value                  | Description                                                  |
-| ----------------------- | --------- | ------------------------------ | ------------------------------------------------------------ |
-| `mainClass`             | Yes       | `null`                         | Full path to your app main class.                            |
-| `bundleJre`             | No        | `false`                        | Embed a customized JRE with the app.                         |
-| `forceJreOptimization`  | No        | `false`                        | Although JDK version < 13, it will try to reduce the bundled JRE. |
-| `jrePath`               | No        | `""`                           | Path to JRE folder. If specified, it will bundle this JRE with the app, and won't generate a customized JRE. For Java 8 version or least. |
-| `administratorRequired` | No        | `false`                        | If true, app will run with administrator privileges.         |
-| `additionalResources`   | No        | []                             | Additional files and folders to include in the bundled app.  |
-| `generateInstaller`     | No        | `true`                         | Generate an installer for the app.                           |
-| `displayName`           | No        | `${project.name}`              | App name to show.                                            |
-| `iconFile`              | No        | `null`                         | Path to the app icon file (PNG, ICO or ICNS).                |
-| `licenseFile`           | No        | `${project.licenses[0].url}`   | Path to project license file.                                |
-| `url`                   | No        | `null`                         | App website URL.                                             |
-| `organizationName`      | No        | `${project.organization.name}` | Organization name.                                           |
-| `organizationUrl`       | No        | `${project.organization.url}`  | Organization website URL.                                    |
-| `organizationEmail`     | No        | `null`                         | Organization email.                                          |
+| Property                          | Mandatory | Default value                  | Description                                                                                                                                                      |
+| --------------------------------- | --------- | ------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `mainClass`                       | Yes       | `null`                         | Full path to your app main class.                                                                                                                                |
+| `bundleJre`                       | No        | `false`                        | Embed a customized JRE with the app.                                                                                                                             |
+| `forceJreOptimization`            | No        | `false`                        | Although JDK version < 13, it will try to reduce the bundled JRE.                                                                                                |
+| `jrePath`                         | No        | `""`                           | Path to JRE folder. If specified, it will bundle this JRE with the app, and won't generate a customized JRE. For Java 8 version or least.                        |
+| `moduleDependenceAnalysisOption`  | No        | `"--list-deps"`                | When generating a customized JRE, this option allows to specify a different Module dependence analysis option other than the default (--list-deps) for jdeps     |
+| `additionalModules`               | No        | `""`                           | When generating a customized JRE, allows adding aditional modules other than the ones identified by jdeps before calling jlink.                                  |
+| `administratorRequired`           | No        | `false`                        | If true, app will run with administrator privileges.                                                                                                             |
+| `additionalResources`             | No        | []                             | Additional files and folders to include in the bundled app.                                                                                                      |
+| `generateInstaller`               | No        | `true`                         | Generate an installer for the app.                                                                                                                               |
+| `displayName`                     | No        | `${project.name}`              | App name to show.                                                                                                                                                |
+| `iconFile`                        | No        | `null`                         | Path to the app icon file (PNG, ICO or ICNS).                                                                                                                    |
+| `licenseFile`                     | No        | `${project.licenses[0].url}`   | Path to project license file.                                                                                                                                    |
+| `url`                             | No        | `null`                         | App website URL.                                                                                                                                                 |
+| `organizationName`                | No        | `${project.organization.name}` | Organization name.                                                                                                                                               |
+| `organizationUrl`                 | No        | `${project.organization.url}`  | Organization website URL.                                                                                                                                        |
+| `organizationEmail`               | No        | `null`                         | Organization email.                                                                                                                                              |
 
 Some assets, such as application icons, could be located in `assets` folder organized by platform, and so it would not be necessary to specify the `iconFile` property:
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>fvarrui.maven</groupId>
 	<artifactId>javapackager</artifactId>
-	<version>0.8.4</version>
+	<version>0.8.5-SNAPSHOT</version>
 	<packaging>maven-plugin</packaging>
 
 	<name>JavaPackager Maven Plugin</name>

--- a/src/main/java/fvarrui/maven/plugin/javapackager/PackageMojo.java
+++ b/src/main/java/fvarrui/maven/plugin/javapackager/PackageMojo.java
@@ -125,6 +125,12 @@ public class PackageMojo extends AbstractMojo {
 	@Parameter(property = "additionalResources", required = false)
 	private List<File> additionalResources;
 
+	@Parameter(defaultValue = "--list-deps", property = "moduleDependenceAnalysisOption", required = false)
+	private String moduleDependenceAnalysisOption;
+
+	@Parameter(defaultValue = "", property = "additionalModules", required = false)
+	private String additionalModules;
+
 	public PackageMojo() {
 		super();
 		Logger.init(getLog());
@@ -674,9 +680,9 @@ public class PackageMojo extends AbstractMojo {
 				jdeps.getAbsolutePath(), 
 				"-q", 
 				additionalArguments, 
-				"--list-deps", 
+				moduleDependenceAnalysisOption, 
 				"--multi-release", JavaUtils.getJavaMajorVersion(),
-				new File(libsFolder, "*"), 
+				new File(libsFolder, "*.jar"), 
 				jarFile
 			);
 		
@@ -686,6 +692,9 @@ public class PackageMojo extends AbstractMojo {
 				.map(module -> module.trim())
 				.filter(module -> !module.startsWith("JDK removed internal"))
 				.collect(Collectors.toList());
+		if (!StringUtils.isEmpty(additionalModules)) {
+			modulesList.addAll(Arrays.asList(additionalModules.split(",")).stream().map(module->module.trim()).collect(Collectors.toList()));
+		}
 		
 		return StringUtils.join(modulesList, ",");
 	}


### PR DESCRIPTION
- Added parameter for specifying a different Module Dependence Analysis Option other than the default (--list-deps)
- Added parameter for specifying additional modules than the ones calculated by jdeps before calling jlink
- Fixed a problem when inside libs folder there are other artifacts beside jars (ie: wars)