### PR TITLE
Add workflow for Update Gradle Wrapper Action.

### DIFF
--- a/.github/workflows/update-gradle-wrapper.yml
+++ b/.github/workflows/update-gradle-wrapper.yml
@@ -1,0 +1,17 @@
+name: Update Gradle Wrapper
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  update-gradle-wrapper:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Update Gradle Wrapper
+        uses: gradle-update/update-gradle-wrapper-action@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Hey there 👋, first of all thanks for your work on JavaPackager!

I've got a suggested change: would you be willing to use [this GitHub Action](https://github.com/gradle-update/update-gradle-wrapper-action) to automatically keep Gradle Wrapper updated to latest release?

**What does "Update Gradle Wrapper Action" do?** It can be configured to run at scheduled intervals (e.g. daily or weekly) and will check whether the Wrapper script in the repo is up-to-date to the latest Gradle release: in case a new Gradle version is available, it will create a PR to update the Wrapper. And that's it!

**Why is that a good thing?** Well, first of all it alleviates the chore of manually updating the Wrapper, as you got a task that keeps track of new Gradle releases for you! More importantly, it boosts security around the Wrapper update and usage processes: this actions verifies that the `gradle-wrapper.jar` file has not been tampered with (uses checksum comparison), and it sets the `distributionSha256Sum` property so that the new Gradle binary itself will be verified locally upon download.

**Where can I find more about?** The [README](https://github.com/gradle-update/update-gradle-wrapper-action/blob/master/README.md) contains quite detailed information!

In this PR I propose adding a new workflow which runs the action every day at midnight (but feel free to adjust the frequency as you prefer). I've verified it works correctly in my fork of the repo, and you can [see here](https://github.com/gradle-update/JavaPackager/pull/1) how the generated PR looks like.

The action is under active development, you can have a look at the [list of inputs](https://github.com/gradle-update/update-gradle-wrapper-action#action-inputs) currently supported. There's new features coming up soon and if you'd like to request any particular change just let me know!

I'd love to see the action used by JavaPackager and I genuinely hope you can find this useful. Would love your feedback! ❤️