### PR TITLE
New feature "removeApplicationLink" for Mac OS X to remove link to /Application dir

### DIFF
--- a/docs/macosx-specific-properties.md
+++ b/docs/macosx-specific-properties.md
@@ -8,6 +8,7 @@
 	<generateDmg>true|false</generateDmg>
 	<generatePkg>true|false</generatePkg>
 	<relocateJar>true|false</relocateJar>
+	<removeApplicationLink>true|false</removeApplicationLink>
 	<!-- signing properties -->
     	<developerId>singning identity</developerId>
     	<entitlements>path/to/entitlements.plist</entitlements>
@@ -34,6 +35,8 @@
 | `generateDmg`  | :x:       | `true`         | Enables DMG disk image file generation.                      |
 | `generatePkg`  | :x:       | `true`         | Enables installation package generation.                     |
 | `relocateJar`  | :x:       | `true`         | If `true`, Jar files are located in `Contents/Resources/Java` folder, otherwise they are located in `Contents/Resources` folder. |
+|
+| `removeApplicationLink`  | :x:       | `removeApplicationLink`         | If `true`, application link in build folder shall be removed after build. |
 | `appId`        | :x:       | `${mainClass}` | App unique identifier.                                       |
 | `developerId`  | :x:       | `null`         | Signing identity.                                            |
 | `entitlements` | :x:       | `null`         | Path to [entitlements](https://developer.apple.com/documentation/bundleresources/entitlements) file. |

--- a/src/main/java/io/github/fvarrui/javapackager/model/MacConfig.java
+++ b/src/main/java/io/github/fvarrui/javapackager/model/MacConfig.java
@@ -27,6 +27,7 @@ public class MacConfig implements Serializable {
 	private boolean generateDmg = true;
 	private boolean generatePkg = true;
 	private boolean relocateJar = true;
+	private boolean removeApplicationLink = true;
 	private String appId;
 	private String developerId = "-";
 	private File entitlements;
@@ -167,6 +168,14 @@ public class MacConfig implements Serializable {
 		this.relocateJar = relocateJar;
 	}
 
+	public boolean isRemoveApplicationLink() {
+		return removeApplicationLink;
+	}
+
+	public void setRemoveApplicationLink(boolean removeApplicationLink) {
+		this.removeApplicationLink = removeApplicationLink;
+	}
+
 	public String getAppId() {
 		return appId;
 	}
@@ -198,7 +207,9 @@ public class MacConfig implements Serializable {
 				+ ", iconSize=" + iconSize + ", textSize=" + textSize + ", iconX=" + iconX + ", iconY=" + iconY
 				+ ", appsLinkIconX=" + appsLinkIconX + ", appsLinkIconY=" + appsLinkIconY + ", volumeIcon=" + volumeIcon
 				+ ", volumeName=" + volumeName + ", generateDmg=" + generateDmg + ", generatePkg=" + generatePkg
-				+ ", relocateJar=" + relocateJar + ", appId=" + appId + ", developerId=" + developerId
+				+ ", relocateJar=" + relocateJar
+				+ ", removeApplicationLink=" + removeApplicationLink
+				+ ", appId=" + appId + ", developerId=" + developerId
 				+ ", entitlements=" + entitlements + "]";
 	}
 

--- a/src/main/java/io/github/fvarrui/javapackager/packagers/GenerateDmg.java
+++ b/src/main/java/io/github/fvarrui/javapackager/packagers/GenerateDmg.java
@@ -1,7 +1,7 @@
 package io.github.fvarrui.javapackager.packagers;
 
-import static org.apache.commons.lang3.StringUtils.defaultIfBlank;
 import static io.github.fvarrui.javapackager.utils.CommandUtils.execute;
+import static org.apache.commons.lang3.StringUtils.defaultIfBlank;
 
 import java.io.File;
 import java.util.Arrays;
@@ -127,6 +127,16 @@ public class GenerateDmg extends ArtifactGenerator {
 		// unmounts
 		Logger.info("Unmounting volume: " + mountFolder);
 		execute("hdiutil", "detach", mountFolder);
+		
+		// remove application link (if required)
+		boolean removeApplicationLink = macPackager.getMacConfig().isRemoveApplicationLink();
+		if (removeApplicationLink) {
+			boolean success = linkFile.delete();
+			if (success)
+				Logger.info("Application link successfully deleted");
+			else
+				Logger.info("Could not delete Application link");
+		}
 		
 		// compress image
 		Logger.info("Compressing disk image...");


### PR DESCRIPTION
Hello guys,

on Mac OS X I am getting high CPU usage with my Eclipse IDE. This happens on following situation

1. a Maven build was executed and the application containing a symbolic link to /Application was build successfully and
1. Eclipse is refreshing the project or
1. Eclipse is rebuilding the whole workspace.

I was able to figure out that Eclipse starts to scan the whole /Applications folder on my Mac when encountering the target directory with the symbolic link.

As of that I have created this pull request. I added a new flag "removeApplicationLink" to this plugin. The symbolic link to /Application is deleted after successful build, if this flag ist true. The default value is "true" and can be overwritten by corresponding parameter in Pom file.