### PR TITLE
Fixed synatx error in XML Tag

### DIFF
--- a/docs/linux-specific-properties.md
+++ b/docs/linux-specific-properties.md
@@ -2,8 +2,8 @@
 
 ```xml
 <linuxConfig>
-	<pngFile>path/to/icon.png<pngFile>
-	<xpmFile>path/to/icon.png<xpmFile>
+	<pngFile>path/to/icon.png</pngFile>
+	<xpmFile>path/to/icon.png</xpmFile>
 	<generateDeb>true|false</generateDeb>
 	<generateRpm>true|false</generateRpm>
 </linuxConfig>


### PR DESCRIPTION
Fixed XML Tag syntax:
```
<pngFile>path/to/icon.png</pngFile>
<xpmFile>path/to/icon.png</xpmFile>
```