### PR TITLE
Use gradle toolchains for packaging jdk

### DIFF
--- a/src/main/java/io/github/fvarrui/javapackager/gradle/PackagePluginExtension.java
+++ b/src/main/java/io/github/fvarrui/javapackager/gradle/PackagePluginExtension.java
@@ -13,6 +13,12 @@ import io.github.fvarrui.javapackager.model.Manifest;
 import io.github.fvarrui.javapackager.model.Platform;
 import io.github.fvarrui.javapackager.model.WindowsConfig;
 import io.github.fvarrui.javapackager.packagers.PackagerSettings;
+import org.gradle.api.internal.provider.Providers;
+import org.gradle.api.plugins.JavaPluginExtension;
+import org.gradle.api.provider.Provider;
+import org.gradle.jvm.toolchain.JavaLauncher;
+import org.gradle.jvm.toolchain.JavaToolchainService;
+import org.gradle.jvm.toolchain.JavaToolchainSpec;
 
 /**
  * JavaPackager plugin extension for Gradle  

--- a/src/main/java/io/github/fvarrui/javapackager/packagers/BundleJre.java
+++ b/src/main/java/io/github/fvarrui/javapackager/packagers/BundleJre.java
@@ -45,7 +45,7 @@ public class BundleJre extends ArtifactGenerator {
 		List<String> additionalModules = packager.getAdditionalModules();
 		List<File> additionalModulePaths = packager.getAdditionalModulePaths();
 		
-		File currentJdk = new File(System.getProperty("java.home"));
+		File currentJdk = packager.packagingJdk;
 		
 		Logger.infoIndent("Bundling JRE ... with " + currentJdk);
 		

--- a/src/main/java/io/github/fvarrui/javapackager/packagers/PackagerSettings.java
+++ b/src/main/java/io/github/fvarrui/javapackager/packagers/PackagerSettings.java
@@ -55,6 +55,15 @@ public class PackagerSettings {
 	protected String jreMinVersion;
 	protected Manifest manifest;
 	protected List<File> additionalModulePaths;
+	protected File packagingJdk;
+
+	public File getPackagingJdk() {
+		return packagingJdk;
+	}
+
+	public void setPackagingJdk(File packagingJdk) {
+		this.packagingJdk = packagingJdk;
+	}
 
 	public File getOutputDirectory() {
 		return outputDirectory;
@@ -216,6 +225,11 @@ public class PackagerSettings {
 
 	public PackagerSettings outputDirectory(File outputDirectory) {
 		this.outputDirectory = outputDirectory;
+		return this;
+	}
+
+	public PackagerSettings packagingJdk(File packagingJdk) {
+		this.packagingJdk = packagingJdk;
 		return this;
 	}
 


### PR DESCRIPTION
Fixes #111 

Java packager will now use the set toolchain to run jlink and other jdk commands when packaging. This fixes issues with packaging a newer JRE than the current JDK.

Will use either the global setting,
```groovy
java {
      toolchain {
          // Gradle will download the JDK for compiling/running/packaging if one isn't found
          // This should prevent anyone from using an outdated JDK
          languageVersion.set(JavaLanguageVersion.of(shippingJava))
      }
  }
```
a task specific setting, provided as,
```groovy
tasks.register("blah", PackageTask) {
  packagingJdk = javaToolchains.launcherFor {// Force it to use a different Java version
              languageVersion = JavaLanguageVersion.of(shippingJava)
  }.get().metadata.installationPath.asFile // I know this is ugly, but it works
}
```
or, uses the current `java.home` jdk, which is current behavior.

Notes:
Doesn't fix 112, this commit could be cherrypicked/retargeted to another branch.

The packager should probably try and catch the error to give a better message when the packaged jdk and the packaging jdk are mismatched, though the user can also implement a task SKIP and error log in that case.

Configuring it in the extension doesn't work, I believe it resolves too early.