### PR TITLE
Workaround for `afterEvaluate` call in gradle-launch4j

### DIFF
--- a/src/main/java/io/github/fvarrui/javapackager/gradle/CreateWindowsExe.java
+++ b/src/main/java/io/github/fvarrui/javapackager/gradle/CreateWindowsExe.java
@@ -3,7 +3,6 @@ package io.github.fvarrui.javapackager.gradle;
 import java.io.File;
 import java.util.HashSet;
 import java.util.List;
-import java.util.UUID;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -53,7 +52,8 @@ public class CreateWindowsExe extends WindowsArtifactGenerator {
 		
 		String jarPath = winConfig.isWrapJar() ? genericJar.getAbsolutePath() : jarFile.getName();
 		
-		Launch4jLibraryTask l4jTask = createLaunch4jTask();
+		Launch4jLibraryTask l4jTask = Context.getGradleContext().getLibraryTask();
+		l4jTask.getOutputs().upToDateWhen(task -> false);
 		l4jTask.setHeaderType(winConfig.getHeaderType().toString());
 		l4jTask.setJar(jarPath);
 		l4jTask.setDontWrapJar(!winConfig.isWrapJar());
@@ -85,10 +85,6 @@ public class CreateWindowsExe extends WindowsArtifactGenerator {
 		FileUtils.copyFileToFile(genericExe, executable);
 		
 		return executable;
-	}
-	
-	private Launch4jLibraryTask createLaunch4jTask() {
-		return Context.getGradleContext().getProject().getTasks().create("launch4j_" + UUID.randomUUID(), Launch4jLibraryTask.class);
 	}
 	
 	private void createAssets(WindowsPackager packager) throws Exception {

--- a/src/main/java/io/github/fvarrui/javapackager/gradle/GradleContext.java
+++ b/src/main/java/io/github/fvarrui/javapackager/gradle/GradleContext.java
@@ -1,7 +1,10 @@
 package io.github.fvarrui.javapackager.gradle;
 
 import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
 
+import edu.sc.seis.launch4j.tasks.Launch4jLibraryTask;
 import org.gradle.api.Project;
 import org.gradle.api.logging.Logger;
 
@@ -14,6 +17,8 @@ import io.github.fvarrui.javapackager.packagers.Packager;
 public class GradleContext extends Context<Logger> {
 
 	private Project project;
+
+	private Launch4jLibraryTask libraryTask;
 	
 	public GradleContext(Project project) {
 		super();
@@ -67,6 +72,14 @@ public class GradleContext extends Context<Logger> {
 	@Override
 	public File createWindowsExe(Packager packager) throws Exception {
 		return new CreateWindowsExe().apply(packager);	
+	}
+
+	public Launch4jLibraryTask getLibraryTask() {
+		return libraryTask;
+	}
+
+	public void setLibraryTask(Launch4jLibraryTask libraryTask) {
+		this.libraryTask = libraryTask;
 	}
 
 }

--- a/src/main/java/io/github/fvarrui/javapackager/gradle/PackagePlugin.java
+++ b/src/main/java/io/github/fvarrui/javapackager/gradle/PackagePlugin.java
@@ -1,9 +1,11 @@
 package io.github.fvarrui.javapackager.gradle;
 
+import edu.sc.seis.launch4j.tasks.Launch4jLibraryTask;
+import io.github.fvarrui.javapackager.packagers.Context;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 
-import io.github.fvarrui.javapackager.packagers.Context;
+import java.util.UUID;
 
 /**
  * JavaPackager Gradle plugin
@@ -24,6 +26,8 @@ public class PackagePlugin implements Plugin<Project> {
 		
 		project.getExtensions().create(SETTINGS_EXT_NAME, PackagePluginExtension.class, project);
 		project.getTasks().create(PACKAGE_TASK_NAME, DefaultPackageTask.class).dependsOn("build");
+
+		Context.getGradleContext().setLibraryTask(project.getTasks().create("launch4j_" + UUID.randomUUID(), Launch4jLibraryTask.class));
 
 	}
 


### PR DESCRIPTION
This is a workaround for and closes #112 
This creates the l4j task when the plugin is applied and simply reuses as needed.

Does not rely on the updated gradle-launch4j.

Tested with the example project provided in #112 