### PR TITLE
Search PATH for JRE in Windows

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,7 @@ dependencies {
     implementation 'org.apache.velocity:velocity-engine-core:2.0'
     implementation 'edu.sc.seis.launch4j:launch4j:2.5.0'
     implementation 'com.netflix.nebula:gradle-ospackage-plugin:8.4.1'
-	implementation 'net.jsign:jsign-core:3.1'
+    implementation 'net.jsign:jsign-core:3.1'
 	
     testImplementation 'junit:junit:4.12'
     

--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,9 @@ plugins {
 repositories {
 	mavenLocal()
 	mavenCentral()
+    maven {
+        url 'https://plugins.gradle.org/m2/'
+    }
 }
 
 gradlePlugin {
@@ -47,8 +50,8 @@ dependencies {
     implementation 'commons-io:commons-io:2.6'
     implementation 'org.apache.commons:commons-collections4:4.1'
     implementation 'org.apache.velocity:velocity-engine-core:2.0'
-	implementation 'io.github.fvarrui:gradle-launch4j:2.4.7'
-	implementation 'com.netflix.nebula:gradle-ospackage-plugin:8.4.1'
+    implementation 'edu.sc.seis.launch4j:launch4j:2.5.0'
+    implementation 'com.netflix.nebula:gradle-ospackage-plugin:8.4.1'
 	implementation 'net.jsign:jsign-core:3.1'
 	
     testImplementation 'junit:junit:4.12'
@@ -116,6 +119,12 @@ task generatePluginDescriptor(type: JavaExec, dependsOn: compileJava) {
                .mavenInstaller
                .pom
                .withXml {
+                   asNode().appendNode('repositories').appendNode('repository')
+                           .with {
+                               appendNode('id', 'gradle')
+                               appendNode('name', 'Gradle Plugin Portal')
+                               appendNode('url', 'https://plugins.gradle.org/m2/')
+                           }
                     asNode().appendNode('build')
                             .with {
                                 appendNode('directory', directory)

--- a/src/main/java/io/github/fvarrui/javapackager/gradle/CreateWindowsExe.java
+++ b/src/main/java/io/github/fvarrui/javapackager/gradle/CreateWindowsExe.java
@@ -1,5 +1,12 @@
 package io.github.fvarrui.javapackager.gradle;
 
+import java.io.File;
+import java.util.HashSet;
+import java.util.List;
+import java.util.UUID;
+
+import org.apache.commons.lang3.StringUtils;
+
 import edu.sc.seis.launch4j.tasks.Launch4jLibraryTask;
 import io.github.fvarrui.javapackager.model.WindowsConfig;
 import io.github.fvarrui.javapackager.packagers.Context;
@@ -7,12 +14,6 @@ import io.github.fvarrui.javapackager.packagers.Packager;
 import io.github.fvarrui.javapackager.packagers.WindowsArtifactGenerator;
 import io.github.fvarrui.javapackager.packagers.WindowsPackager;
 import io.github.fvarrui.javapackager.utils.FileUtils;
-import org.apache.commons.lang3.StringUtils;
-
-import java.io.File;
-import java.util.HashSet;
-import java.util.List;
-import java.util.UUID;
 
 /**
  * Creates Windows native executable on Gradle context

--- a/src/main/java/io/github/fvarrui/javapackager/gradle/CreateWindowsExe.java
+++ b/src/main/java/io/github/fvarrui/javapackager/gradle/CreateWindowsExe.java
@@ -1,12 +1,5 @@
 package io.github.fvarrui.javapackager.gradle;
 
-import java.io.File;
-import java.util.HashSet;
-import java.util.List;
-import java.util.UUID;
-
-import org.apache.commons.lang3.StringUtils;
-
 import edu.sc.seis.launch4j.tasks.Launch4jLibraryTask;
 import io.github.fvarrui.javapackager.model.WindowsConfig;
 import io.github.fvarrui.javapackager.packagers.Context;
@@ -14,6 +7,12 @@ import io.github.fvarrui.javapackager.packagers.Packager;
 import io.github.fvarrui.javapackager.packagers.WindowsArtifactGenerator;
 import io.github.fvarrui.javapackager.packagers.WindowsPackager;
 import io.github.fvarrui.javapackager.utils.FileUtils;
+import org.apache.commons.lang3.StringUtils;
+
+import java.io.File;
+import java.util.HashSet;
+import java.util.List;
+import java.util.UUID;
 
 /**
  * Creates Windows native executable on Gradle context
@@ -63,7 +62,7 @@ public class CreateWindowsExe extends WindowsArtifactGenerator {
 		l4jTask.setMainClassName(mainClass);
 		l4jTask.setClasspath(new HashSet<>(windowsPackager.getClasspaths()));
 		l4jTask.setChdir(useResourcesAsWorkingDir ? "." : "");
-		l4jTask.setBundledJrePath(bundleJre ? jreDirectoryName : "%JAVA_HOME%");
+		l4jTask.setBundledJrePath(bundleJre ? jreDirectoryName : "%JAVA_HOME%;%PATH%");
 		if (!StringUtils.isBlank(jreMinVersion)) { 
 			l4jTask.setJreMinVersion(jreMinVersion);
 		}

--- a/src/main/java/io/github/fvarrui/javapackager/maven/CreateWindowsExe.java
+++ b/src/main/java/io/github/fvarrui/javapackager/maven/CreateWindowsExe.java
@@ -1,28 +1,19 @@
 package io.github.fvarrui.javapackager.maven;
 
-import static org.twdata.maven.mojoexecutor.MojoExecutor.artifactId;
-import static org.twdata.maven.mojoexecutor.MojoExecutor.configuration;
-import static org.twdata.maven.mojoexecutor.MojoExecutor.element;
-import static org.twdata.maven.mojoexecutor.MojoExecutor.executeMojo;
-import static org.twdata.maven.mojoexecutor.MojoExecutor.goal;
-import static org.twdata.maven.mojoexecutor.MojoExecutor.groupId;
-import static org.twdata.maven.mojoexecutor.MojoExecutor.plugin;
-import static org.twdata.maven.mojoexecutor.MojoExecutor.version;
-
-import java.io.File;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Collectors;
-
-import org.apache.commons.lang3.StringUtils;
-import org.twdata.maven.mojoexecutor.MojoExecutor.Element;
-
 import io.github.fvarrui.javapackager.model.WindowsConfig;
 import io.github.fvarrui.javapackager.packagers.Context;
 import io.github.fvarrui.javapackager.packagers.Packager;
 import io.github.fvarrui.javapackager.packagers.WindowsArtifactGenerator;
 import io.github.fvarrui.javapackager.packagers.WindowsPackager;
 import io.github.fvarrui.javapackager.utils.FileUtils;
+import org.apache.commons.lang3.StringUtils;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.twdata.maven.mojoexecutor.MojoExecutor.*;
 
 /**
  * Copies all dependencies to app folder on Maven context
@@ -68,7 +59,7 @@ public class CreateWindowsExe extends WindowsArtifactGenerator {
 		
 		List<Element> jreElements = new ArrayList<>();
 		jreElements.add(element("opts", optsElements.toArray(new Element[optsElements.size()])));
-		jreElements.add(element("path", bundleJre ? jreDirectoryName : "%JAVA_HOME%"));
+		jreElements.add(element("path", bundleJre ? jreDirectoryName : "%JAVA_HOME%;%PATH%"));
 		if (!StringUtils.isBlank(jreMinVersion)) {
 			jreElements.add(element("minVersion", jreMinVersion));
 		}

--- a/src/main/java/io/github/fvarrui/javapackager/maven/CreateWindowsExe.java
+++ b/src/main/java/io/github/fvarrui/javapackager/maven/CreateWindowsExe.java
@@ -1,19 +1,28 @@
 package io.github.fvarrui.javapackager.maven;
 
-import io.github.fvarrui.javapackager.model.WindowsConfig;
-import io.github.fvarrui.javapackager.packagers.Context;
-import io.github.fvarrui.javapackager.packagers.Packager;
-import io.github.fvarrui.javapackager.packagers.WindowsArtifactGenerator;
-import io.github.fvarrui.javapackager.packagers.WindowsPackager;
-import io.github.fvarrui.javapackager.utils.FileUtils;
-import org.apache.commons.lang3.StringUtils;
+import static org.twdata.maven.mojoexecutor.MojoExecutor.artifactId;
+import static org.twdata.maven.mojoexecutor.MojoExecutor.configuration;
+import static org.twdata.maven.mojoexecutor.MojoExecutor.element;
+import static org.twdata.maven.mojoexecutor.MojoExecutor.executeMojo;
+import static org.twdata.maven.mojoexecutor.MojoExecutor.goal;
+import static org.twdata.maven.mojoexecutor.MojoExecutor.groupId;
+import static org.twdata.maven.mojoexecutor.MojoExecutor.plugin;
+import static org.twdata.maven.mojoexecutor.MojoExecutor.version;
 
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static org.twdata.maven.mojoexecutor.MojoExecutor.*;
+import org.apache.commons.lang3.StringUtils;
+import org.twdata.maven.mojoexecutor.MojoExecutor.Element;
+
+import io.github.fvarrui.javapackager.model.WindowsConfig;
+import io.github.fvarrui.javapackager.packagers.Context;
+import io.github.fvarrui.javapackager.packagers.Packager;
+import io.github.fvarrui.javapackager.packagers.WindowsArtifactGenerator;
+import io.github.fvarrui.javapackager.packagers.WindowsPackager;
+import io.github.fvarrui.javapackager.utils.FileUtils;
 
 /**
  * Copies all dependencies to app folder on Maven context


### PR DESCRIPTION
Most of the JRE installations in Windows (including Oracle JRE) do not add `JAVA_HOME` environment variable after installation. In this case the generated `exe` file will fail to run because it cannot find the JRE. 

This PR will include `%PATH%` along side `%JAVA_HOME%` to search for JRE. This feature is implemented in Launch4j 3.13 based on [FR 127](https://sourceforge.net/p/launch4j/feature-requests/127/). 

For this reason both maven and gradle plugins for Launch4j need to be upgraded. Maven plugin is already upgraded to 2.1.1. This PR also upgrades gradle plugin to `edu.sc.seis.launch4j:launch4j:2.5.0`
