### PR TITLE
enable codesign hardened runtime

### DIFF
--- a/src/main/java/io/github/fvarrui/javapackager/packagers/MacPackager.java
+++ b/src/main/java/io/github/fvarrui/javapackager/packagers/MacPackager.java
@@ -149,6 +149,7 @@ public class MacPackager extends Packager {
 	private void codesign(String developerId, File entitlements, File appFile) throws IOException, CommandLineException {
 		List<Object> codesignArgs = new ArrayList<>();
 		codesignArgs.add("--force");
+		codesignArgs.add("--options runtime");
 		codesignArgs.add("--deep");
 		if (entitlements == null) {
 			Logger.warn("Entitlements file not specified");


### PR DESCRIPTION
Hi,  can this be added to your JavaPackager to enable codesign hardened runtime so packages can pass notarization on the newer macOS versions?

I know that on macOS versions pre 10.13.6, the --options runtime are not supported, so for legacy macOS users, maybe it needs to be provided as an option in codesigning with javapackager?

Thank you,
Mabula Haverkamp
