### PR TITLE
Rename property

### DIFF
--- a/docs/macosx-specific-properties.md
+++ b/docs/macosx-specific-properties.md
@@ -11,7 +11,7 @@
     <relocateJar>true|false</relocateJar>
 
     <!-- signing properties -->
-    <developerId>singning identity</developerId>
+    <developerCertificateName>singning identity</developerCertificateName>
     <entitlements>path/to/entitlements.plist</entitlements>
     <codesignApp>true|false</codesignApp>
 
@@ -48,13 +48,13 @@
 ```
 
 | Property       | Mandatory | Default value  | Description                                                                                                                      |
-| -------------- | --------- | -------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| -------------- | --------- | -------------- |----------------------------------------------------------------------------------------------------------------------------------|
 | `icnsFile`     | :x:       | `null`         | Icon file.                                                                                                                       |
 | `generateDmg`  | :x:       | `true`         | Enables DMG disk image file generation.                                                                                          |
 | `generatePkg`  | :x:       | `true`         | Enables installation package generation.                                                                                         |
 | `relocateJar`  | :x:       | `true`         | If `true`, Jar files are located in `Contents/Resources/Java` folder, otherwise they are located in `Contents/Resources` folder. |
 | `appId`        | :x:       | `${mainClass}` | App unique identifier.                                                                                                           |
-| `developerId`  | :x:       | `null`         | Signing identity.                                                                                                                |
+| `developerCertificateName`  | :x:       | `null`         | Name of the signing certificate. For example: `3rd Party Mac Developer Application: Max Musterman (6W37Y3F4CM)`                  |
 | `entitlements` | :x:       | `null`         | Path to [entitlements](https://developer.apple.com/documentation/bundleresources/entitlements) file.                             |
 | `codesignApp`  | :x:       | `true`         | If it is set to `false`, generated app will not be codesigned.                                                                   |
 

--- a/src/main/java/io/github/fvarrui/javapackager/model/MacConfig.java
+++ b/src/main/java/io/github/fvarrui/javapackager/model/MacConfig.java
@@ -31,7 +31,7 @@ public class MacConfig implements Serializable {
 	private boolean generatePkg = true;
 	private boolean relocateJar = true;
 	private String appId;
-	private String developerId = "-";
+	private String developerCertificateName = "-";
 	private File entitlements;
 	private boolean codesignApp = true;
 	private InfoPlist infoPlist = new InfoPlist();
@@ -182,12 +182,12 @@ public class MacConfig implements Serializable {
 		this.appId = appId;
 	}
 
-	public String getDeveloperId() {
-		return developerId;
+	public String getDeveloperCertificateName() {
+		return developerCertificateName;
 	}
 
-	public void setDeveloperId(String developerId) {
-		this.developerId = developerId;
+	public void setDeveloperCertificateName(String developerCertificateName) {
+		this.developerCertificateName = developerCertificateName;
 	}
 
 	public File getEntitlements() {
@@ -237,7 +237,7 @@ public class MacConfig implements Serializable {
 				+ ", iconSize=" + iconSize + ", textSize=" + textSize + ", iconX=" + iconX + ", iconY=" + iconY
 				+ ", appsLinkIconX=" + appsLinkIconX + ", appsLinkIconY=" + appsLinkIconY + ", volumeIcon=" + volumeIcon
 				+ ", volumeName=" + volumeName + ", generateDmg=" + generateDmg + ", generatePkg=" + generatePkg
-				+ ", relocateJar=" + relocateJar + ", appId=" + appId + ", developerId=" + developerId
+				+ ", relocateJar=" + relocateJar + ", appId=" + appId + ", developerId=" + developerCertificateName
 				+ ", entitlements=" + entitlements + ", codesignApp=" + codesignApp + ", infoPlist=" + infoPlist
 				+ ", hardenedCodesign=" + hardenedCodesign + ", macStartup=" + macStartup + "]";
 	}

--- a/src/main/java/io/github/fvarrui/javapackager/packagers/MacPackager.java
+++ b/src/main/java/io/github/fvarrui/javapackager/packagers/MacPackager.java
@@ -144,7 +144,7 @@ public class MacPackager extends Packager {
 		} else if (!getMacConfig().isCodesignApp()) {
 			Logger.warn("App codesigning disabled");
 		} else {
-			codesign(this.macConfig.getDeveloperId(), this.macConfig.getEntitlements(), this.appFile);
+			codesign(this.macConfig.getDeveloperCertificateName(), this.macConfig.getEntitlements(), this.appFile);
 		}
 
 		return appFile;


### PR DESCRIPTION
Rename the `developerId` property to make it more clear what is needed.