### PR TITLE
Fix codesigning if JRE not bundled

### DIFF
--- a/src/main/java/io/github/fvarrui/javapackager/packagers/MacPackager.java
+++ b/src/main/java/io/github/fvarrui/javapackager/packagers/MacPackager.java
@@ -276,8 +276,10 @@ public class MacPackager extends Packager {
 			});
 		}
 
-		// sign the JRE itself after signing all its contents
-		codesign(developerCertificateName, jreBundleFolder);
+		if(bundleJre) {
+			// sign the JRE itself after signing all its contents
+			codesign(developerCertificateName, jreBundleFolder);
+		}
 
 		// make sure the executable is signed last
 		codesign(entitlements, developerCertificateName, this.executable);


### PR DESCRIPTION
I realized I missed this conditional in the other PR, and this line would almost certainly fail without a bundled jre.

Edit: tested and confirmed without this change it is broken if bundleJre = false, with this change it successfully signs and notarizes.