### PR TITLE
Upgrade to gradle 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ cd JavaPackager
 Run next command (ommit `./` on Windows):
 
 ```bash
-./gradlew -Prelease uploadArchives closeAndReleaseRepository
+./gradlew publish closeAndReleaseRepository
 ```
 
 > Related [guide](https://nemerosa.ghost.io/2015/07/01/publishing-to-the-maven-central-using-gradle/).

--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,12 @@
 plugins {
 	id 'java'    
-	id 'maven'
 	id 'maven-publish'
 	id 'java-gradle-plugin'
-	id 'com.gradle.plugin-publish' version '0.12.0'
+	id 'com.gradle.plugin-publish' version '1.1.0'
 	id 'io.codearte.nexus-staging' version '0.21.2'
 	id 'eclipse'
 	id 'de.undercouch.download' version '5.0.4'
+	id 'signing'
 }
 
 repositories {
@@ -18,22 +18,16 @@ repositories {
 }
 
 gradlePlugin {
-	plugins {
-		javaPackagerPlugin {
-			id = 'io.github.fvarrui.javapackager.plugin'
-			implementationClass = 'io.github.fvarrui.javapackager.gradle.PackagePlugin'
-		}
-	}
-}
-
-pluginBundle {
 	website = 'http://github.com/fvarrui/JavaPackager'
 	vcsUrl = 'http://github.com/fvarrui/JavaPackager.git'
 	description = 'Packages Java applications as native Windows, MacOS or GNU/Linux executables and creates installers for them'
-	tags = ['java', 'packager', 'gradle-plugin', 'maven-plugin', 'native', 'installer', 'debian-packages', 'rpm-packages', 'dmg', 'maven', 'gradle', 'distribution', 'javapackager', 'linux-executables', 'deb', 'rpm', 'native-windows', 'java-applications', 'pkg', 'msi']
+
 	plugins {
-		javaPackagerPlugin {
+		create("javaPackagerPlugin") {
+			id = 'io.github.fvarrui.javapackager.plugin'
 			displayName = 'JavaPackager'
+			implementationClass = 'io.github.fvarrui.javapackager.gradle.PackagePlugin'
+			tags.set(['java', 'packager', 'gradle-plugin', 'maven-plugin', 'native', 'installer', 'debian-packages', 'rpm-packages', 'dmg', 'maven', 'gradle', 'distribution', 'javapackager', 'linux-executables', 'deb', 'rpm', 'native-windows', 'java-applications', 'pkg', 'msi'])
 		}
 	}
 }
@@ -78,150 +72,111 @@ targetCompatibility = JavaVersion.VERSION_1_8
 
 compileJava.options.encoding = 'UTF-8'
 
-publishing {
-	publications {
-		mavenJava(MavenPublication) {
-			from(components.java)
-		}
-	}
-}
-
 java {
 	withSourcesJar()
-	// and/or analogously use "withJavadocJar()" to get a "javadocJar" task
-}
-
-install.repositories.mavenInstaller.pom.with {
-	groupId = project.group
-	artifactId = project.name
-	version = project.version
-	description = project.description
-	packaging = 'maven-plugin'
+	withJavadocJar()
 }
 
 build.dependsOn ':winrun4j-launcher:build'
 
+// OSSRH publication
+publishing {
+	repositories {
+		maven {
+			name = "OSSRH"
+			url = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+
+			url = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+
+			credentials {
+				username = project.findProperty("ossrhUser") ?: ''
+				password = project.findProperty("ossrhPassword") ?: ''
+			}
+		}
+	}
+	publications {
+		pluginMaven(MavenPublication) {
+			def directory = buildDir.canonicalPath
+			def outputDirectory = compileJava.destinationDirectory.asFile.get().canonicalPath
+			pom.withXml {
+				asNode().appendNode('build')
+						.with {
+							appendNode('directory', directory)
+							appendNode('outputDirectory', outputDirectory)
+						}
+			}
+
+			pom {
+				groupId = project.group
+				artifactId = project.name
+				version = project.version
+				description = project.description
+
+				packaging = 'maven-plugin'
+				url = 'https://github.com/fvarrui/JavaPackager'
+
+				scm {
+					connection = 'scm:git:git://github.com/fvarrui/JavaPackager.git'
+					developerConnection = 'scm:git:git@github.com:fvarrui/fvarrui.git'
+					url = 'https://github.com/fvarrui/JavaPackager'
+				}
+
+				licenses {
+					license {
+						name = 'GPL-v3.0'
+						url = 'http://www.gnu.org/licenses/gpl-3.0.txt'
+						distribution = 'repo'
+					}
+				}
+
+				developers {
+					developer {
+						id = 'fvarrui'
+						name = 'Francisco Vargas Ruiz'
+						url = 'https://github.com/fvarrui'
+					}
+				}
+			}
+		}
+	}
+}
+
 // runs the plugin description generator
 task generatePluginDescriptor(type: JavaExec, dependsOn: compileJava) {
-
-	def pomFile = file("$buildDir/pom.xml")
-	def pluginDescriptorFile = new File(project.compileJava.destinationDir, 'META-INF/maven/plugin.xml')
-	def directory = buildDir.canonicalPath
-	def outputDirectory = compileJava.destinationDir.canonicalPath
+	def pluginDescriptorFile = new File(project.compileJava.destinationDirectory.asFile.get(), 'META-INF/maven/plugin.xml')
 
 	// FIXME: this does not seem to be working
 	inputs.files project.compileJava.outputs.files
 	outputs.file pluginDescriptorFile
 
 	classpath = configurations.mavenEmbedder
-	main = 'org.apache.maven.cli.MavenCli'
+	mainClass = 'org.apache.maven.cli.MavenCli'
 	systemProperties['maven.multiModuleProjectDirectory'] = projectDir
 	args = [
 			'--errors',
 			'--batch-mode',
-			'--file', "${buildDir}/pom.xml",
+			'--file', generatePomFileForPluginMavenPublication.destination,
 			'org.apache.maven.plugins:maven-plugin-plugin:3.6.0:descriptor',
 			'-Dproject.build.sourceEncoding=' + compileJava.options.encoding
 	]
-
-	doFirst {
-		install.repositories
-				.mavenInstaller
-				.pom
-				.withXml {
-					asNode().appendNode('repositories').appendNode('repository')
-						.with {
-							appendNode('id', 'gradle')
-							appendNode('name', 'Gradle Plugin Portal')
-							appendNode('url', 'https://plugins.gradle.org/m2/')                    		
-						}
-					asNode().appendNode('build')
-						.with {
-							appendNode('directory', directory)
-							appendNode('outputDirectory', outputDirectory)
-						}
-				}
-				.writeTo(pomFile)
-
-		assert pomFile.file, "${pomFile.canonicalPath}: was not generated"
-		logger.info("POM is generated in ${pomFile.canonicalPath}")
-	}
-
 	doLast {
 		assert pluginDescriptorFile.file, "${pluginDescriptorFile.canonicalPath}: was not generated"
 		logger.info("Plugin descriptor is generated in ${pluginDescriptorFile.canonicalPath}")
 	}
 }
+generatePluginDescriptor.dependsOn(generatePomFileForPluginMavenPublication)
 
-project.jar.dependsOn(generatePluginDescriptor)
+project.classes.dependsOn(generatePluginDescriptor)
+project.validatePlugins.dependsOn(generatePluginDescriptor)
 publishToMavenLocal.dependsOn(build)
-    
-if (project.hasProperty('release')) {
 
-	apply plugin: 'signing'
-	apply plugin: 'maven'
-
-	task deployingJavadocJar(type: Jar) {
-		classifier = 'javadoc'
-		from javadoc
+// Signature of publication
+signing {
+	setRequired {
+		// signing is only required if the artifacts are to be published
+		gradle.taskGraph.allTasks.any { it instanceof PublishToMavenRepository }
 	}
-	
-	task deployingSourcesJar(type: Jar) {
-		classifier = 'sources'
-		from sourceSets.main.allSource
-	}
-	
-	artifacts {
-		archives deployingJavadocJar, deployingSourcesJar
-	}
-
-	// Signature of artifacts
-	signing {
-		sign configurations.archives
-	}
-
-	// OSSRH publication
-	uploadArchives {
-		repositories {
-			mavenDeployer {
-				// POM signature
-				beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
-				// Target repository
-				repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
-					authentication(userName: ossrhUser, password: ossrhPassword)
-				}
-				pom.project {
-					name project.name
-					description project.description
-					packaging = 'maven-plugin'
-					url 'https://github.com/fvarrui/JavaPackager'
-
-					scm {
-						connection 'scm:git:git://github.com/fvarrui/JavaPackager.git'
-						developerConnection 'scm:git:git@github.com:fvarrui/fvarrui.git'
-						url 'https://github.com/fvarrui/JavaPackager'
-					}
-
-					licenses {
-						license {
-							name 'GPL-v3.0'
-							url 'http://www.gnu.org/licenses/gpl-3.0.txt'
-							distribution 'repo'
-						}
-					}
-
-					developers {
-						developer {
-							id = 'fvarrui'
-							name = 'Francisco Vargas Ruiz'
-							url = 'https://github.com/fvarrui'
-						}
-					}
-				}
-			}
-		}
-	}
-	
+	sign publishing.publications.pluginMaven
 }
 
 nexusStaging {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=7faa7198769f872826c8ef4f1450f839ec27f0b4d5d1e51bade63667cbccd205
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/winrun4j-launcher/build.gradle
+++ b/winrun4j-launcher/build.gradle
@@ -16,8 +16,8 @@ ext {
 }
 
 jar {
-	archiveBaseName = baseName
-	archiveVersion =  version
+	archiveBaseName = project.baseName
+	archiveVersion =  project.version
 }
 
 task copyArtifact {


### PR DESCRIPTION
This allows local development to work with java 17.

I have tested that publishing to maven local works correctly
with javas 8, 11, and 17.  I have not tested publishing to
maven central/staging as I do not have access to do so. I
have tested publishing to a different repository with a
custom repository block, and that appeared to work correctly,
but I wouldn't be surprised if this needs tweaks to be happy
for maven central.
