### PR TITLE
fix(docs): Broken link to the artifact in Maven Central repository search

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # JavaPackager
 
-[![Maven Central](http://img.shields.io/maven-central/v/io.github.fvarrui/javapackager)](https://search.maven.org/artifact/io.github.fvarrui/javapackager)
+[![Maven Central](http://img.shields.io/maven-central/v/io.github.fvarrui/javapackager)](https://central.sonatype.com/artifact/io.github.fvarrui/javapackager/1.7.0)
 [![GPL-3.0](https://img.shields.io/badge/license-GPL--3.0-%250778B9.svg)](https://www.gnu.org/licenses/gpl-3.0.html)
 
 JavaPackager is a hybrid plugin for **Maven** and **Gradle** which provides an easy way to package Java applications in native Windows, MacOS or GNU/Linux executables, and generate installers for them.


### PR DESCRIPTION
Maven has a new search repository for its artifacts. So, I have updated the link to the new repository.

![image](https://user-images.githubusercontent.com/105960032/227796166-a7c51c42-595f-4021-9b92-c0b2e136de26.png)
