### PR TITLE
Minor change to the Windows Properties documentation

### DIFF
--- a/docs/windows-specific-properties.md
+++ b/docs/windows-specific-properties.md
@@ -10,7 +10,7 @@
     <generateMsm>true|false</generateMsm>
 
     <!-- exe creation properties -->
-    <headerType>gui</headerType>
+    <headerType>gui|console</headerType>
     <wrapJar>true|false</wrapJar>
     <companyName>${organizationName}</companyName>
     <fileVersion>1.0.0.0</fileVersion>


### PR DESCRIPTION
I submitted this in a PR before, but I think you committed it to the DEVEL branch and it needs to be committed to the main branch so that it becomes part of the public-facing documentation.

The issue is that in the markdown file under the docs folder with the name:
```
windows-specific-properties.md
```
The listed options for header type shows `gui` as being the only option. However, both `gui` and `console` are valid options for that setting, so the line in the document should look like this:
```XML
<headerType>gui|console</headerType>
```
This needs to be merged into the main branch so that the change is visible in the public-facing documentation here in the repository.