### PR TITLE
Include necessary metadata in gradle plugin POM

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -114,27 +114,37 @@ publishing {
 				name = project.name
 				groupId = project.group
 				artifactId = project.name
-				version = project.version
-				description = project.description
 				packaging = 'maven-plugin'
-				url = 'https://github.com/fvarrui/JavaPackager'
-				scm {
-					connection = 'scm:git:git://github.com/fvarrui/JavaPackager.git'
-					developerConnection = 'scm:git:git@github.com:fvarrui/fvarrui.git'
+			}
+		}
+	}
+
+	afterEvaluate {
+		publications {
+			withType(MavenPublication) {
+				// customize all publications here
+				pom {
+					version = project.version
+					description = project.description
 					url = 'https://github.com/fvarrui/JavaPackager'
-				}
-				licenses {
-					license {
-						name = 'GPL-v3.0'
-						url = 'http://www.gnu.org/licenses/gpl-3.0.txt'
-						distribution = 'repo'
+					scm {
+						connection = 'scm:git:git://github.com/fvarrui/JavaPackager.git'
+						developerConnection = 'scm:git:git@github.com:fvarrui/fvarrui.git'
+						url = 'https://github.com/fvarrui/JavaPackager'
 					}
-				}
-				developers {
-					developer {
-						id = 'fvarrui'
-						name = 'Francisco Vargas Ruiz'
-						url = 'https://github.com/fvarrui'
+					licenses {
+						license {
+							name = 'GPL-v3.0'
+							url = 'http://www.gnu.org/licenses/gpl-3.0.txt'
+							distribution = 'repo'
+						}
+					}
+					developers {
+						developer {
+							id = 'fvarrui'
+							name = 'Francisco Vargas Ruiz'
+							url = 'https://github.com/fvarrui'
+						}
 					}
 				}
 			}


### PR DESCRIPTION
This should fix the publication error when pushing to gradle by adding the relevant metadata to the POM.  This will create a [plugin marker](https://docs.gradle.org/current/userguide/plugins.html#sec:plugin_markers) on Maven central, which should allow plugin configuration through the plugin DSL.

In settings.gradle:
```
pluginManagement {
    repositories {
        mavenCentral()/mavenLocal()/maven {
            url "https://oss.sonatype.org/content/repositories/snapshots"
        }
        gradlePluginPortal()
    }
}
```

In build.gradle:
```
plugins {
    ...
    id 'io.github.fvarrui.javapackager.plugin' version '1.7.3-SNAPSHOT'
}
```