### PR TITLE
Added ability to name the shortcut created during Windows app install.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,7 +64,7 @@ dependencies {
 }
 
 group = 'io.github.fvarrui'
-version = '1.7.2'
+version = '1.7.3-SNAPSHOT'
 description = 'Hybrid Maven/Gradle plugin to package Java applications as native Windows, Mac OS X or GNU/Linux executables and create installers for them'
 
 sourceCompatibility = JavaVersion.VERSION_1_8
@@ -209,4 +209,3 @@ task updateWhyJavaLauncher(type : Download) {
 	dest file('src/main/resources/windows')
     overwrite true
 }
-

--- a/docs/windows-specific-properties.md
+++ b/docs/windows-specific-properties.md
@@ -21,6 +21,7 @@
     <copyright>${organizationName}</copyright>
     <productName>${name}</productName>
     <internalName>${name}</internalName>
+    <txtShortcutName>${name}</txtShortcutName>
     <originalFilename>${name}.exe</originalFilename>
 
     <!-- choose EXE creation tool -->
@@ -77,7 +78,7 @@
 ## Exe creation properties
 
 | Property            | Mandatory | Default value         | Description                                                                                                                                                       |
-| ------------------- | --------- | --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|---------------------| --------- |-----------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `headerType`        | :x:       | `"gui"`               | EXE header type: `console` or `gui`.                                                                                                                              |
 | `wrapJar`           | :x:       | `true`                | Wrap JAR file in native EXE.                                                                                                                                      |
 | `companyName`       | :x:       | `${organizationName}` | EXE company name.                                                                                                                                                 |
@@ -100,9 +101,10 @@
 ## Setup generation properties
 
 | Property                  | Mandatory | Default value                                                                              | Description                                                                                    |
-| ------------------------- | --------- | ------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------- |
+|---------------------------| --------- |--------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------|
 | `setupMode`               | :x:       | `installForAllUsers`                                                                       | Setup installation mode: require administrative privileges or not. [*](#setupmode)             |
 | `setupLanguages`          | :x:       | `<english>compiler:Default.isl</english><spanish>compiler:Languages\Spanish.isl</spanish>` | Map with setup languages.                                                                      |
+| `txtShortcutName`         | :x:       | `${name}`                                                                                  | Sets the name of the user optional shortcut created on the desktop                             |
 | `disableDirPage`          | :x:       | `true`                                                                                     | If this is set to `true`, Setup will not show the **Select Destination Location** wizard page. |
 | `disableProgramGroupPage` | :x:       | `true`                                                                                     | If this is set to `true`, Setup will not show the **Select Start Menu Folder** wizard page.    |
 | `disableFinishedPage`     | :x:       | `true`                                                                                     | If this is set to `true`, Setup will not show the **Setup Completed** wizard page.             |

--- a/src/main/java/io/github/fvarrui/javapackager/model/WindowsConfig.java
+++ b/src/main/java/io/github/fvarrui/javapackager/model/WindowsConfig.java
@@ -30,6 +30,7 @@ public class WindowsConfig implements Serializable {
 	private String trademarks;
 	private String txtFileVersion;
 	private String txtProductVersion;
+	private String txtShortcutName;
 	private boolean disableDirPage = true;
 	private boolean disableProgramGroupPage = true;
 	private boolean disableFinishedPage = true;
@@ -151,6 +152,14 @@ public class WindowsConfig implements Serializable {
 
 	public void setTxtProductVersion(String txtProductVersion) {
 		this.txtProductVersion = txtProductVersion;
+	}
+
+	public String getTxtShortcutName() {
+		return txtShortcutName;
+	}
+
+	public void setTxtShortcutName(String txtShortcutName) {
+		this.txtShortcutName = txtShortcutName;
 	}
 
 	public String getInternalName() {
@@ -312,6 +321,7 @@ public class WindowsConfig implements Serializable {
 				+ ", internalName=" + internalName + ", language=" + language + ", originalFilename=" + originalFilename
 				+ ", productName=" + productName + ", productVersion=" + productVersion + ", trademarks=" + trademarks
 				+ ", txtFileVersion=" + txtFileVersion + ", txtProductVersion=" + txtProductVersion
+				+ ", txtShortcutName=" + txtShortcutName
 				+ ", disableDirPage=" + disableDirPage + ", disableProgramGroupPage=" + disableProgramGroupPage
 				+ ", disableFinishedPage=" + disableFinishedPage + ", disableRunAfterInstall=" + disableRunAfterInstall
 				+ ", disableWelcomePage=" + disableWelcomePage + ", createDesktopIconTask=" + createDesktopIconTask
@@ -331,6 +341,7 @@ public class WindowsConfig implements Serializable {
 		this.setFileVersion(defaultIfBlank(this.getFileVersion(), "1.0.0.0"));
 		this.setTxtFileVersion(defaultIfBlank(this.getTxtFileVersion(), "" + packager.getVersion()));
 		this.setProductVersion(defaultIfBlank(this.getProductVersion(), "1.0.0.0"));
+		this.setTxtShortcutName(defaultIfBlank(this.getTxtShortcutName(), packager.getName()));
 		this.setTxtProductVersion(defaultIfBlank(this.getTxtProductVersion(), "" + packager.getVersion()));
 		this.setCompanyName(defaultIfBlank(this.getCompanyName(), packager.getOrganizationName()));
 		this.setCopyright(defaultIfBlank(this.getCopyright(), packager.getOrganizationName()));
@@ -340,5 +351,4 @@ public class WindowsConfig implements Serializable {
 		this.setOriginalFilename(defaultIfBlank(this.getOriginalFilename(), packager.getName() + ".exe"));
 		this.setMsiUpgradeCode(defaultIfBlank(this.getMsiUpgradeCode(), UUID.randomUUID().toString()));
 	}
-
 }

--- a/src/main/resources/windows/iss.vtl
+++ b/src/main/resources/windows/iss.vtl
@@ -6,6 +6,7 @@
 \#define MyAppFolder "${info.name}"
 \#define MyAppLicense "$!{info.licenseFile.absolutePath}"
 \#define MyAppIcon "${info.iconFile.absolutePath}"
+\#define MyShortcutName = "${info.winConfig.txtShortcutName}"
 
 [Setup]
 AppId={{{#MyAppName}}}
@@ -85,7 +86,7 @@ Source: "${info.appFolder}\*"; DestDir: "{app}"; Flags: ignoreversion recursesub
 [Icons]
 Name: "{autoprograms}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; IconFilename: "{app}\\${info.iconFile.name}"
 #if ($info.winConfig.createDesktopIconTask)
-Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; IconFilename: "{app}\\${info.iconFile.name}"; Tasks: desktopicon
+Name: "{autodesktop}\{#MyShortcutName}"; Filename: "{app}\{#MyAppExeName}"; IconFilename: "{app}\\${info.iconFile.name}"; Tasks: desktopicon
 #end
 
 [Run]


### PR DESCRIPTION
Tested with and without using the new pom file property:

```XML
<winConfig> 
    <txtShortcutName>My Shortcut Name</txtShortcutName> 
</winConfig> 
```

It works when the setting is used and if it's not used, it defaults to `${name}` (I tested both scenarios)

Also modified the markdown file to document the change and set the library version to `1.7.3-SNAPSHOT`

Here is a summary of the code changes I made:

in `io.github.fvarrui.javapackager.model.WindowsConfig` I added:

```Java
private String txtShortcutName;

public String getTxtShortcutName() {
    return txtShortcutName;
}

public void setTxtShortcutName(String txtShortcutName) {
    this.txtShortcutName = txtShortcutName;
}

public String toString() {
    + ", txtShortcutName=" + txtShortcutName //added to existing code
}

public void setDefaults(Packager packager) {
    this.setTxtShortcutName(defaultIfBlank(this.getTxtShortcutName(), packager.getName())); //added to existing code
}
```
Then in the `iss.vtl` file, I added this to the top and changed the related value in the `[Icons]' section:
```
\#define MyShortcutName = "${info.winConfig.txtShortcutName}"

[Icons]
Name: "{autodesktop}\{#MyShortcutName}"; Filename: "{app}\{#MyAppExeName}"; IconFilename: "
```

This addresses Issue https://github.com/fvarrui/JavaPackager/issues/318