### PR TITLE
Docs: Added a new project in the README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ It was born while teaching to my students how to build and distribute their Java
 
 - [AstroImageJ](http://astroimagej.com/)
 - [Astro Pixel Processor](https://www.astropixelprocessor.com/)
+- [Drifty](https://github.com/SaptarshiSarkar12/Drifty)
 - [GistFX](https://github.com/RedmondSims/GistFX)
 - [Spektar Design Lab](https://spektar.io/)
 


### PR DESCRIPTION
I have added a new project which uses the JavaPackager Maven plugin to build executables and installers to distribute the Java application. Link to the project - https://github.com/SaptarshiSarkar12/Drifty