### PR TITLE
Update `FileUtils#findFirstFile` to conform to specifications

### DIFF
--- a/src/main/java/io/github/fvarrui/javapackager/utils/FileUtils.java
+++ b/src/main/java/io/github/fvarrui/javapackager/utils/FileUtils.java
@@ -303,7 +303,9 @@ public class FileUtils {
 	 */
 	public static File findFirstFile(File searchFolder, String regex) {
 		return Arrays.asList(searchFolder.listFiles((dir, name) -> Pattern.matches(regex, name))).stream()
-				.map(f -> new File(f.getName())).findFirst().get();
+				.map(f -> new File(f.getName()))
+				.findFirst()
+				.orElse(null);
 	}
 
 	/**


### PR DESCRIPTION
The Javadoc for `FileUtils.java#findFirstFile` states to [return the found file or null if nothing matches](https://github.com/fvarrui/JavaPackager/blob/master/src/main/java/io/github/fvarrui/javapackager/utils/FileUtils.java#L302).

This PR updates the implementation matches the specifications (the previous version throws a run-time exception when no file is found).