### PR TITLE
Configuration Cache Support

### DIFF
--- a/src/main/java/io/github/fvarrui/javapackager/gradle/GradleContext.java
+++ b/src/main/java/io/github/fvarrui/javapackager/gradle/GradleContext.java
@@ -24,10 +24,12 @@ public class GradleContext extends Context<Logger> {
 	private Launch4jLibraryTask libraryTask;
 	private DuplicatesStrategy duplicatesStrategy;
 	private PackagePluginExtension packagePluginExtension;
+	private String defaultVersion;
 
 	public GradleContext(Project project) {
 		super();
 		this.project = project;
+		defaultVersion = project.getVersion().toString();
 	}
 
 	public Logger getLogger() {
@@ -139,5 +141,13 @@ public class GradleContext extends Context<Logger> {
 
     public void setPackagePluginExtension(PackagePluginExtension packagePluginExtension) {
         this.packagePluginExtension = packagePluginExtension;
+    }
+
+    public String getDefaultVersion() {
+        return defaultVersion;
+    }
+
+    public void setDefaultVersion(String defaultVersion) {
+        this.defaultVersion = defaultVersion;
     }
 }

--- a/src/main/java/io/github/fvarrui/javapackager/gradle/GradleContext.java
+++ b/src/main/java/io/github/fvarrui/javapackager/gradle/GradleContext.java
@@ -23,6 +23,7 @@ public class GradleContext extends Context<Logger> {
 	private Project project;
 	private Launch4jLibraryTask libraryTask;
 	private DuplicatesStrategy duplicatesStrategy;
+	private PackagePluginExtension packagePluginExtension;
 
 	public GradleContext(Project project) {
 		super();
@@ -132,4 +133,11 @@ public class GradleContext extends Context<Logger> {
 		return null;
 	}
 
+    public PackagePluginExtension getPackagePluginExtension() {
+        return packagePluginExtension;
+    }
+
+    public void setPackagePluginExtension(PackagePluginExtension packagePluginExtension) {
+        this.packagePluginExtension = packagePluginExtension;
+    }
 }

--- a/src/main/java/io/github/fvarrui/javapackager/gradle/GradleLocalContext.java
+++ b/src/main/java/io/github/fvarrui/javapackager/gradle/GradleLocalContext.java
@@ -1,0 +1,75 @@
+package io.github.fvarrui.javapackager.gradle;
+
+import io.github.fvarrui.javapackager.packagers.LocalContext;
+import io.github.fvarrui.javapackager.utils.Logger;
+import org.gradle.api.Task;
+import org.gradle.api.file.*;
+
+import java.io.File;
+
+public class GradleLocalContext implements LocalContext {
+    final FileSystemOperations fileSystemOperations;
+
+    public GradleLocalContext(FileSystemOperations fileSystemOperations) {
+        this.fileSystemOperations = fileSystemOperations;
+    }
+
+    public FileSystemOperations getFileSystemOperations() {
+        return fileSystemOperations;
+    }
+
+    public void copyAdditionalResources(Object o, File destination) throws Exception {
+        if (o instanceof CopySpec) {
+            getFileSystemOperations().copy(cs -> {
+                cs.with((CopySpec) o);
+                cs.into(destination);
+                cs.eachFile(fcd -> {
+                    if (fcd.isDirectory()) {
+                        Logger.info("Copying folder [" + fcd.getPath() + "] to folder [" + destination + "]");
+                    } else {
+                        Logger.info("Copying file [" + fcd.getPath() + "] to folder [" + destination + "]");
+                    }
+                });
+            });
+        } else if (o instanceof FileCollection) {
+            getFileSystemOperations().copy(cs -> {
+                cs.from((FileCollection) o);
+                cs.into(destination);
+                cs.eachFile(fcd -> {
+                    if (fcd.isDirectory()) {
+                        Logger.info("Copying folder [" + fcd.getPath() + "] to folder [" + destination + "]");
+                    } else {
+                        Logger.info("Copying file [" + fcd.getPath() + "] to folder [" + destination + "]");
+                    }
+                });
+            });
+        } else if (o instanceof Task) {
+            getFileSystemOperations().copy(cs -> {
+                cs.from((Task) o);
+                cs.into(destination);
+                cs.eachFile(fcd -> {
+                    if (fcd.isDirectory()) {
+                        Logger.info("Copying folder [" + fcd.getPath() + "] to folder [" + destination + "]");
+                    } else {
+                        Logger.info("Copying file [" + fcd.getPath() + "] to folder [" + destination + "]");
+                    }
+                });
+            });
+        } else {
+            throw new IllegalArgumentException("Unknown resource type: " + o);
+        }
+    }
+    
+    public File getSingleFile(Object o) {
+        if (o instanceof FileCollection) {
+            return  ((FileCollection) o).getSingleFile();
+        } else if (o instanceof Task) {
+            return  ((Task) o).getOutputs().getFiles().getSingleFile();
+        } /*else if (o instanceof Configuration) {
+            Configuration c = ((Configuration) o);
+            c.resolve()
+        }*/
+
+        return null;
+    }
+}

--- a/src/main/java/io/github/fvarrui/javapackager/gradle/PackagePlugin.java
+++ b/src/main/java/io/github/fvarrui/javapackager/gradle/PackagePlugin.java
@@ -30,6 +30,23 @@ public class PackagePlugin implements Plugin<Project> {
 		Context.getGradleContext().setLibraryTask(project.getTasks().create("launch4j_" + UUID.randomUUID(), Launch4jLibraryTask.class));
 
 		Context.getGradleContext().setPackagePluginExtension(extension);
+
+		// Pass along custom gradle types set in the extension to the task in this manor so that gradle's automatic
+		// task dependency magic can occur, eg. you can specify a task or configuration as an input and gradle will
+		// run it for us
+		project.afterEvaluate(p -> {
+            project.getTasks().withType(PackageTask.class, packageTask -> {
+				if (packageTask.getAdditionalResourceCollection() == null) {
+					packageTask.setAdditionalResourceCollection(extension.getAdditionalResourceCollection());
+				}
+
+				if (packageTask.getRunnableJar() == null &&
+						packageTask.getRunnableJarSource() == null && extension.getRunnableJar() == null) {
+					packageTask.setRunnableJar(extension.getRunnableJarSource());
+				}
+			});
+		});
+
 	}
 
 }

--- a/src/main/java/io/github/fvarrui/javapackager/gradle/PackagePlugin.java
+++ b/src/main/java/io/github/fvarrui/javapackager/gradle/PackagePlugin.java
@@ -24,11 +24,12 @@ public class PackagePlugin implements Plugin<Project> {
 		project.getPluginManager().apply("java");
 		project.getPluginManager().apply("edu.sc.seis.launch4j");		
 		
-		project.getExtensions().create(SETTINGS_EXT_NAME, PackagePluginExtension.class, project);
+		PackagePluginExtension extension = project.getExtensions().create(SETTINGS_EXT_NAME, PackagePluginExtension.class, project);
 		project.getTasks().create(PACKAGE_TASK_NAME, PackageTask.class).dependsOn("build");
 
 		Context.getGradleContext().setLibraryTask(project.getTasks().create("launch4j_" + UUID.randomUUID(), Launch4jLibraryTask.class));
 
+		Context.getGradleContext().setPackagePluginExtension(extension);
 	}
 
 }

--- a/src/main/java/io/github/fvarrui/javapackager/gradle/PackagePluginExtension.java
+++ b/src/main/java/io/github/fvarrui/javapackager/gradle/PackagePluginExtension.java
@@ -16,6 +16,7 @@ import io.github.fvarrui.javapackager.model.Platform;
 import io.github.fvarrui.javapackager.model.Scripts;
 import io.github.fvarrui.javapackager.model.WindowsConfig;
 import io.github.fvarrui.javapackager.packagers.PackagerSettings;
+import org.gradle.api.tasks.TaskProvider;
 
 /**
  * JavaPackager plugin extension for Gradle  
@@ -32,6 +33,7 @@ public class PackagePluginExtension extends PackagerSettings {
 		this.additionalModules = new ArrayList<>();
 		this.additionalModulePaths = new ArrayList<>();
 		this.additionalResources = new ArrayList<>();
+		this.additionalResourceCollection = null;
 		this.administratorRequired = false;
 		this.assetsDir = new File(project.getProjectDir(), "assets");
 		this.bundleJre = true;
@@ -97,4 +99,11 @@ public class PackagePluginExtension extends PackagerSettings {
 		return duplicatesStrategy;
 	}
 
+	@Override
+	public PackagerSettings additionalResourceCollection(Object additionalResources) {
+		if (additionalResources instanceof TaskProvider<?>) {
+			additionalResources = ((TaskProvider<?>) additionalResources).get();
+		}
+		return super.additionalResourceCollection(additionalResources);
+	}
 }

--- a/src/main/java/io/github/fvarrui/javapackager/gradle/PackageTask.java
+++ b/src/main/java/io/github/fvarrui/javapackager/gradle/PackageTask.java
@@ -654,7 +654,7 @@ public class PackageTask extends AbstractPackageTask {
 					.templates(defaultIfNull(templates, extension.getTemplates()))
 					.useResourcesAsWorkingDir(defaultIfNull(useResourcesAsWorkingDir, extension.isUseResourcesAsWorkingDir()))
 					.url(defaultIfNull(url, extension.getUrl()))
-					.version(defaultIfNull(version, extension.getVersion(), getProject().getVersion().toString()))
+					.version(defaultIfNull(version, extension.getVersion(), Context.getGradleContext().getDefaultVersion()))
 					.vmArgs(defaultIfNull(vmArgs, extension.getVmArgs()))
 					.winConfig(defaultIfNull(winConfig, extension.getWinConfig()));
 

--- a/src/main/java/io/github/fvarrui/javapackager/gradle/PackageTask.java
+++ b/src/main/java/io/github/fvarrui/javapackager/gradle/PackageTask.java
@@ -7,12 +7,10 @@ import java.io.File;
 import java.util.List;
 import java.util.Map;
 
+import org.gradle.api.Task;
 import org.gradle.api.file.DuplicatesStrategy;
-import org.gradle.api.tasks.Input;
-import org.gradle.api.tasks.InputDirectory;
-import org.gradle.api.tasks.InputFile;
-import org.gradle.api.tasks.Optional;
-import org.gradle.api.tasks.OutputDirectory;
+import org.gradle.api.file.FileSystemOperations;
+import org.gradle.api.tasks.*;
 
 import groovy.lang.Closure;
 import io.github.fvarrui.javapackager.model.Arch;
@@ -27,6 +25,8 @@ import io.github.fvarrui.javapackager.model.WindowsConfig;
 import io.github.fvarrui.javapackager.packagers.Context;
 import io.github.fvarrui.javapackager.packagers.Packager;
 import io.github.fvarrui.javapackager.packagers.PackagerFactory;
+
+import javax.inject.Inject;
 
 /**
  * Packaging task fro Gradle 
@@ -71,6 +71,23 @@ public class PackageTask extends AbstractPackageTask {
 	
 	public void setAdditionalResources(List<File> additionalResources) {
 		this.additionalResources = additionalResources;
+	}
+
+	@InputFiles
+	@Optional
+	private Object additionalResourceCollection;
+
+	public Object getAdditionalResourceCollection() {
+		return additionalResourceCollection;
+	}
+
+	public void setAdditionalResourceCollection(Object additionalResources) {
+		if (additionalResources instanceof Task) {
+			additionalResources = ((Task) additionalResources).getOutputs().getFiles();
+		} else if (additionalResources instanceof TaskProvider<?>) {
+			additionalResources = ((TaskProvider<?>) additionalResources).get().getOutputs().getFiles();
+		}
+		this.additionalResourceCollection = additionalResources;
 	}
 	
 	@Input
@@ -408,6 +425,18 @@ public class PackageTask extends AbstractPackageTask {
 	public void setRunnableJar(File runnableJar) {
 		this.runnableJar = runnableJar;
 	}
+
+	@Optional
+	@InputFiles
+	private Object runnableJarSource;
+
+	public Object getRunnableJarSource() {
+		return runnableJarSource;
+	}
+
+	public void setRunnableJar(Object runnableJar) {
+		this.runnableJarSource = runnableJar;
+	}
 	
 	@Input
 	@Optional
@@ -599,6 +628,12 @@ public class PackageTask extends AbstractPackageTask {
 		this.duplicatesStrategy = duplicatesStrategy;
 	}
 
+	@Inject
+	protected FileSystemOperations getFileSystemOperator() {
+		// Method body is ignored
+		throw new UnsupportedOperationException();
+	}
+
 	// ===============
 	// create packager
 	// ===============
@@ -614,9 +649,11 @@ public class PackageTask extends AbstractPackageTask {
 		return
 			(Packager) PackagerFactory
 				.createPackager(defaultIfNull(platform, extension.getPlatform()))
+					.setLocalContext(new GradleLocalContext(getFileSystemOperator()))
 					.additionalModules(defaultIfNull(additionalModules, extension.getAdditionalModules()))
 					.additionalModulePaths(defaultIfNull(additionalModulePaths, extension.getAdditionalModulePaths()))
 					.additionalResources(defaultIfNull(additionalResources, extension.getAdditionalResources()))
+					.additionalResourceCollection(defaultIfNull(additionalResourceCollection, extension.getAdditionalResourceCollection()))
 					.administratorRequired(defaultIfNull(administratorRequired, extension.getAdministratorRequired()))
 					.arch(defaultIfNull(arch, extension.getArch()))
 					.assetsDir(defaultIfNull(assetsDir, extension.getAssetsDir()))
@@ -650,6 +687,7 @@ public class PackageTask extends AbstractPackageTask {
 					.outputDirectory(defaultIfNull(outputDirectory, extension.getOutputDirectory()))
 					.packagingJdk(defaultIfNull(packagingJdk, extension.getPackagingJdk(), Context.getGradleContext().getDefaultToolchain()))
 					.runnableJar(defaultIfNull(runnableJar, extension.getRunnableJar()))
+					.runnableJar(defaultIfNull(runnableJarSource, extension.getRunnableJarSource()))
 					.scripts(defaultIfNull(scripts, extension.getScripts()))
 					.templates(defaultIfNull(templates, extension.getTemplates()))
 					.useResourcesAsWorkingDir(defaultIfNull(useResourcesAsWorkingDir, extension.isUseResourcesAsWorkingDir()))

--- a/src/main/java/io/github/fvarrui/javapackager/gradle/PackageTask.java
+++ b/src/main/java/io/github/fvarrui/javapackager/gradle/PackageTask.java
@@ -607,7 +607,7 @@ public class PackageTask extends AbstractPackageTask {
 	@Override
 	protected Packager createPackager() throws Exception {
 
-		PackagePluginExtension extension = getProject().getExtensions().findByType(PackagePluginExtension.class);
+		PackagePluginExtension extension = Context.getGradleContext().getPackagePluginExtension();
 		
 		Context.getGradleContext().setDuplicatesStrategy(defaultIfNull(duplicatesStrategy, extension.getDuplicatesStrategy()));
 		

--- a/src/main/java/io/github/fvarrui/javapackager/packagers/LocalContext.java
+++ b/src/main/java/io/github/fvarrui/javapackager/packagers/LocalContext.java
@@ -1,0 +1,4 @@
+package io.github.fvarrui.javapackager.packagers;
+
+public interface LocalContext {
+}

--- a/src/main/java/io/github/fvarrui/javapackager/packagers/PackagerSettings.java
+++ b/src/main/java/io/github/fvarrui/javapackager/packagers/PackagerSettings.java
@@ -43,6 +43,7 @@ public class PackagerSettings {
 	protected File jrePath;
 	protected File jdkPath;
 	protected List<File> additionalResources;
+	protected Object additionalResourceCollection;
 	protected List<String> modules;
 	protected List<String> additionalModules;
 	protected Platform platform;
@@ -70,7 +71,8 @@ public class PackagerSettings {
 	protected Scripts scripts;
 	protected Arch arch;
 	protected List<Template> templates;
-	
+	private Object runnableJarSource;
+
 	/**
 	 * Get packaging JDK
 	 * @return Packaging JDK
@@ -240,6 +242,14 @@ public class PackagerSettings {
 	}
 
 	/**
+	 * Get additional resourcxes
+	 * @return Additional resources
+	 */
+	public Object getAdditionalResourceCollection() {
+		return additionalResourceCollection;
+	}
+
+	/**
 	 * Get Modules
 	 * @return Modules
 	 */
@@ -285,6 +295,14 @@ public class PackagerSettings {
 	 */
 	public File getRunnableJar() {
 		return runnableJar;
+	}
+
+	/**
+	 * Get runnable JAR
+	 * @return Runnable JAR
+	 */
+	public Object getRunnableJarSource() {
+		return runnableJarSource;
 	}
 
 	/**
@@ -636,6 +654,16 @@ public class PackagerSettings {
 	}
 
 	/**
+	 * Set additional resources
+	 * @param additionalResources Additional resources
+	 * @return Packager settings
+	 */
+	public PackagerSettings additionalResourceCollection(Object additionalResources) {
+		this.additionalResourceCollection = additionalResources;
+		return this;
+	}
+
+	/**
 	 * Set modules list
 	 * @param modules Modules list
 	 * @return Packager settings
@@ -692,6 +720,16 @@ public class PackagerSettings {
 	 */
 	public PackagerSettings runnableJar(File runnableJar) {
 		this.runnableJar = runnableJar;
+		return this;
+	}
+
+	/**
+	 * Set runnable JAR
+	 * @param runnableJar Runnable JAR
+	 * @return Packager settings
+	 */
+	public PackagerSettings runnableJar(Object runnableJar) {
+		this.runnableJarSource = runnableJar;
 		return this;
 	}
 


### PR DESCRIPTION
Fixes #432 

This adds preliminary support for the configuration cache, though more testing is needed. 

I am not able to to tests builds/packages on Linux.

Todo:
- [ ] Runnable jar generation
- [ ] Launch4j exe generation
- [ ] Test other tasks/packaging targets
- [ ] Test toolchain fetching

I am not sure yet on how to handle the runnable jar generation and launch4j generation. With this PR, users who provide their own runnable jar and do not use launch4j are configuration cache compatible (so far to my testing). Maybe JP can provide a `RunnableJar` task type that by default configures the manifest, and `setRunnableJar` is given an overload that can take a AbstractArchiveTask/taskprovider and pull the file from that? It would be a potential annoying breakage for users to have to define their own, even preconfigured, tasks for this.

A nice benefit of the configuration cache is that it can execute tasks in parallel - this includes the package tasks. The speedup is very nice to have, and I believe most of the tools used for packaging are ok to run in that situation (though I certainly am not familiar with them all), but there are a couple of caveats I have found so far:

- If you set in the extension `outputDirectory`, all the tasks will use the same working folder `{outputDirectory}/{appName}` and will conflict with one another. Gradle may automatically handle this if the folder was declared as a task input/output. A user can work around this by assigning each task its own folder/subfolder, though it isn't as nice as having all the completed artifacts in one place. The same is true of the `assets` folder. 
  - Maybe the working folder can be assigned a unique name automatically? Preserving parallelism would be ideal.
- You cannot run two mac packaging tasks in parallel when creating DMGs, as the symlink it needs already exists from the other task (see exception below). I do not know enough about DMG creation to understand if this is fixable by renaming something, perhaps a lock needs to be managed by JP? See stacktrace below. (In my case the two tasks are needed to bundle the correct JRE for intel/arm)

<details>
<summary>Conflicting Mac DMG creation</summary>
```java

 Creating Applications link
  Creating symbolic link [/Volumes/AstroImageJ/Applications] to [/Applications]
DMG image generation failed due to: Could not create symlink /Volumes/AstroImageJ/Applications to /Applications

java.lang.Exception: Could not create symlink /Volumes/AstroImageJ/Applications to /Applications
	at io.github.fvarrui.javapackager.utils.FileUtils.createSymlink(FileUtils.java:261)
	at io.github.fvarrui.javapackager.packagers.GenerateDmg.doApply(GenerateDmg.java:118)
	at io.github.fvarrui.javapackager.packagers.GenerateDmg.doApply(GenerateDmg.java:23)
	at io.github.fvarrui.javapackager.packagers.ArtifactGenerator.apply(ArtifactGenerator.java:44)
	at io.github.fvarrui.javapackager.packagers.Packager.generateInstallers(Packager.java:439)
	at io.github.fvarrui.javapackager.gradle.AbstractPackageTask.doPackage(AbstractPackageTask.java:46)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at org.gradle.internal.reflect.JavaMethod.invoke(JavaMethod.java:125)
	at org.gradle.api.internal.project.taskfactory.StandardTaskAction.doExecute(StandardTaskAction.java:58)
	at org.gradle.api.internal.project.taskfactory.StandardTaskAction.execute(StandardTaskAction.java:51)
	at org.gradle.api.internal.project.taskfactory.StandardTaskAction.execute(StandardTaskAction.java:29)
	at org.gradle.api.internal.tasks.execution.TaskExecution$3.run(TaskExecution.java:244)
	at org.gradle.internal.operations.DefaultBuildOperationRunner$1.execute(DefaultBuildOperationRunner.java:29)
	at org.gradle.internal.operations.DefaultBuildOperationRunner$1.execute(DefaultBuildOperationRunner.java:26)
	at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:66)
	at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:59)
	at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:166)
	at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:59)
	at org.gradle.internal.operations.DefaultBuildOperationRunner.run(DefaultBuildOperationRunner.java:47)
	at org.gradle.api.internal.tasks.execution.TaskExecution.executeAction(TaskExecution.java:229)
	at org.gradle.api.internal.tasks.execution.TaskExecution.executeActions(TaskExecution.java:212)
	at org.gradle.api.internal.tasks.execution.TaskExecution.executeWithPreviousOutputFiles(TaskExecution.java:195)
	at org.gradle.api.internal.tasks.execution.TaskExecution.execute(TaskExecution.java:162)
	at org.gradle.internal.execution.steps.ExecuteStep.executeInternal(ExecuteStep.java:105)
	at org.gradle.internal.execution.steps.ExecuteStep.access$000(ExecuteStep.java:44)
	at org.gradle.internal.execution.steps.ExecuteStep$1.call(ExecuteStep.java:59)
	at org.gradle.internal.execution.steps.ExecuteStep$1.call(ExecuteStep.java:56)
	at org.gradle.internal.operations.DefaultBuildOperationRunner$CallableBuildOperationWorker.execute(DefaultBuildOperationRunner.java:209)
	at org.gradle.internal.operations.DefaultBuildOperationRunner$CallableBuildOperationWorker.execute(DefaultBuildOperationRunner.java:204)
	at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:66)
	at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:59)
	at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:166)
	at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:59)
	at org.gradle.internal.operations.DefaultBuildOperationRunner.call(DefaultBuildOperationRunner.java:53)
	at org.gradle.internal.execution.steps.ExecuteStep.execute(ExecuteStep.java:56)
	at org.gradle.internal.execution.steps.ExecuteStep.execute(ExecuteStep.java:44)
	at org.gradle.internal.execution.steps.CancelExecutionStep.execute(CancelExecutionStep.java:42)
	at org.gradle.internal.execution.steps.TimeoutStep.executeWithoutTimeout(TimeoutStep.java:75)
	at org.gradle.internal.execution.steps.TimeoutStep.execute(TimeoutStep.java:55)
	at org.gradle.internal.execution.steps.PreCreateOutputParentsStep.execute(PreCreateOutputParentsStep.java:50)
	at org.gradle.internal.execution.steps.PreCreateOutputParentsStep.execute(PreCreateOutputParentsStep.java:28)
	at org.gradle.internal.execution.steps.RemovePreviousOutputsStep.execute(RemovePreviousOutputsStep.java:67)
	at org.gradle.internal.execution.steps.RemovePreviousOutputsStep.execute(RemovePreviousOutputsStep.java:37)
	at org.gradle.internal.execution.steps.BroadcastChangingOutputsStep.execute(BroadcastChangingOutputsStep.java:61)
	at org.gradle.internal.execution.steps.BroadcastChangingOutputsStep.execute(BroadcastChangingOutputsStep.java:26)
	at org.gradle.internal.execution.steps.CaptureOutputsAfterExecutionStep.execute(CaptureOutputsAfterExecutionStep.java:69)
	at org.gradle.internal.execution.steps.CaptureOutputsAfterExecutionStep.execute(CaptureOutputsAfterExecutionStep.java:46)
	at org.gradle.internal.execution.steps.ResolveInputChangesStep.execute(ResolveInputChangesStep.java:40)
	at org.gradle.internal.execution.steps.ResolveInputChangesStep.execute(ResolveInputChangesStep.java:29)
	at org.gradle.internal.execution.steps.BuildCacheStep.executeWithoutCache(BuildCacheStep.java:189)
	at org.gradle.internal.execution.steps.BuildCacheStep.lambda$execute$1(BuildCacheStep.java:75)
	at org.gradle.internal.Either$Right.fold(Either.java:175)
	at org.gradle.internal.execution.caching.CachingState.fold(CachingState.java:62)
	at org.gradle.internal.execution.steps.BuildCacheStep.execute(BuildCacheStep.java:73)
	at org.gradle.internal.execution.steps.BuildCacheStep.execute(BuildCacheStep.java:48)
	at org.gradle.internal.execution.steps.StoreExecutionStateStep.execute(StoreExecutionStateStep.java:46)
	at org.gradle.internal.execution.steps.StoreExecutionStateStep.execute(StoreExecutionStateStep.java:35)
	at org.gradle.internal.execution.steps.SkipUpToDateStep.executeBecause(SkipUpToDateStep.java:75)
	at org.gradle.internal.execution.steps.SkipUpToDateStep.lambda$execute$2(SkipUpToDateStep.java:53)
	at java.base/java.util.Optional.orElseGet(Optional.java:364)
	at org.gradle.internal.execution.steps.SkipUpToDateStep.execute(SkipUpToDateStep.java:53)
	at org.gradle.internal.execution.steps.SkipUpToDateStep.execute(SkipUpToDateStep.java:35)
	at org.gradle.internal.execution.steps.legacy.MarkSnapshottingInputsFinishedStep.execute(MarkSnapshottingInputsFinishedStep.java:37)
	at org.gradle.internal.execution.steps.legacy.MarkSnapshottingInputsFinishedStep.execute(MarkSnapshottingInputsFinishedStep.java:27)
	at org.gradle.internal.execution.steps.ResolveIncrementalCachingStateStep.executeDelegate(ResolveIncrementalCachingStateStep.java:49)
	at org.gradle.internal.execution.steps.ResolveIncrementalCachingStateStep.executeDelegate(ResolveIncrementalCachingStateStep.java:27)
	at org.gradle.internal.execution.steps.AbstractResolveCachingStateStep.execute(AbstractResolveCachingStateStep.java:71)
	at org.gradle.internal.execution.steps.AbstractResolveCachingStateStep.execute(AbstractResolveCachingStateStep.java:39)
	at org.gradle.internal.execution.steps.ResolveChangesStep.execute(ResolveChangesStep.java:65)
	at org.gradle.internal.execution.steps.ResolveChangesStep.execute(ResolveChangesStep.java:36)
	at org.gradle.internal.execution.steps.ValidateStep.execute(ValidateStep.java:107)
	at org.gradle.internal.execution.steps.ValidateStep.execute(ValidateStep.java:56)
	at org.gradle.internal.execution.steps.AbstractCaptureStateBeforeExecutionStep.execute(AbstractCaptureStateBeforeExecutionStep.java:64)
	at org.gradle.internal.execution.steps.AbstractCaptureStateBeforeExecutionStep.execute(AbstractCaptureStateBeforeExecutionStep.java:43)
	at org.gradle.internal.execution.steps.AbstractSkipEmptyWorkStep.executeWithNonEmptySources(AbstractSkipEmptyWorkStep.java:125)
	at org.gradle.internal.execution.steps.AbstractSkipEmptyWorkStep.execute(AbstractSkipEmptyWorkStep.java:56)
	at org.gradle.internal.execution.steps.AbstractSkipEmptyWorkStep.execute(AbstractSkipEmptyWorkStep.java:36)
	at org.gradle.internal.execution.steps.legacy.MarkSnapshottingInputsStartedStep.execute(MarkSnapshottingInputsStartedStep.java:38)
	at org.gradle.internal.execution.steps.LoadPreviousExecutionStateStep.execute(LoadPreviousExecutionStateStep.java:36)
	at org.gradle.internal.execution.steps.LoadPreviousExecutionStateStep.execute(LoadPreviousExecutionStateStep.java:23)
	at org.gradle.internal.execution.steps.HandleStaleOutputsStep.execute(HandleStaleOutputsStep.java:75)
	at org.gradle.internal.execution.steps.HandleStaleOutputsStep.execute(HandleStaleOutputsStep.java:41)
	at org.gradle.internal.execution.steps.AssignMutableWorkspaceStep.lambda$execute$0(AssignMutableWorkspaceStep.java:35)
	at org.gradle.api.internal.tasks.execution.TaskExecution$4.withWorkspace(TaskExecution.java:289)
	at org.gradle.internal.execution.steps.AssignMutableWorkspaceStep.execute(AssignMutableWorkspaceStep.java:31)
	at org.gradle.internal.execution.steps.AssignMutableWorkspaceStep.execute(AssignMutableWorkspaceStep.java:22)
	at org.gradle.internal.execution.steps.ChoosePipelineStep.execute(ChoosePipelineStep.java:40)
	at org.gradle.internal.execution.steps.ChoosePipelineStep.execute(ChoosePipelineStep.java:23)
	at org.gradle.internal.execution.steps.ExecuteWorkBuildOperationFiringStep.lambda$execute$2(ExecuteWorkBuildOperationFiringStep.java:67)
	at java.base/java.util.Optional.orElseGet(Optional.java:364)
	at org.gradle.internal.execution.steps.ExecuteWorkBuildOperationFiringStep.execute(ExecuteWorkBuildOperationFiringStep.java:67)
	at org.gradle.internal.execution.steps.ExecuteWorkBuildOperationFiringStep.execute(ExecuteWorkBuildOperationFiringStep.java:39)
	at org.gradle.internal.execution.steps.IdentityCacheStep.execute(IdentityCacheStep.java:46)
	at org.gradle.internal.execution.steps.IdentityCacheStep.execute(IdentityCacheStep.java:34)
	at org.gradle.internal.execution.steps.IdentifyStep.execute(IdentifyStep.java:48)
	at org.gradle.internal.execution.steps.IdentifyStep.execute(IdentifyStep.java:35)
	at org.gradle.internal.execution.impl.DefaultExecutionEngine$1.execute(DefaultExecutionEngine.java:61)
	at org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter.executeIfValid(ExecuteActionsTaskExecuter.java:127)
	at org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter.execute(ExecuteActionsTaskExecuter.java:116)
	at org.gradle.api.internal.tasks.execution.ProblemsTaskPathTrackingTaskExecuter.execute(ProblemsTaskPathTrackingTaskExecuter.java:40)
	at org.gradle.api.internal.tasks.execution.FinalizePropertiesTaskExecuter.execute(FinalizePropertiesTaskExecuter.java:46)
	at org.gradle.api.internal.tasks.execution.ResolveTaskExecutionModeExecuter.execute(ResolveTaskExecutionModeExecuter.java:51)
	at org.gradle.api.internal.tasks.execution.SkipTaskWithNoActionsExecuter.execute(SkipTaskWithNoActionsExecuter.java:57)
	at org.gradle.api.internal.tasks.execution.SkipOnlyIfTaskExecuter.execute(SkipOnlyIfTaskExecuter.java:74)
	at org.gradle.api.internal.tasks.execution.CatchExceptionTaskExecuter.execute(CatchExceptionTaskExecuter.java:36)
	at org.gradle.api.internal.tasks.execution.EventFiringTaskExecuter$1.executeTask(EventFiringTaskExecuter.java:77)
	at org.gradle.api.internal.tasks.execution.EventFiringTaskExecuter$1.call(EventFiringTaskExecuter.java:55)
	at org.gradle.api.internal.tasks.execution.EventFiringTaskExecuter$1.call(EventFiringTaskExecuter.java:52)
	at org.gradle.internal.operations.DefaultBuildOperationRunner$CallableBuildOperationWorker.execute(DefaultBuildOperationRunner.java:209)
	at org.gradle.internal.operations.DefaultBuildOperationRunner$CallableBuildOperationWorker.execute(DefaultBuildOperationRunner.java:204)
	at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:66)
	at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:59)
	at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:166)
	at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:59)
	at org.gradle.internal.operations.DefaultBuildOperationRunner.call(DefaultBuildOperationRunner.java:53)
	at org.gradle.api.internal.tasks.execution.EventFiringTaskExecuter.execute(EventFiringTaskExecuter.java:52)
	at org.gradle.execution.plan.LocalTaskNodeExecutor.execute(LocalTaskNodeExecutor.java:42)
	at org.gradle.execution.taskgraph.DefaultTaskExecutionGraph$InvokeNodeExecutorsAction.execute(DefaultTaskExecutionGraph.java:331)
	at org.gradle.execution.taskgraph.DefaultTaskExecutionGraph$InvokeNodeExecutorsAction.execute(DefaultTaskExecutionGraph.java:318)
	at org.gradle.execution.taskgraph.DefaultTaskExecutionGraph$BuildOperationAwareExecutionAction.lambda$execute$0(DefaultTaskExecutionGraph.java:314)
	at org.gradle.internal.operations.CurrentBuildOperationRef.with(CurrentBuildOperationRef.java:85)
	at org.gradle.execution.taskgraph.DefaultTaskExecutionGraph$BuildOperationAwareExecutionAction.execute(DefaultTaskExecutionGraph.java:314)
	at org.gradle.execution.taskgraph.DefaultTaskExecutionGraph$BuildOperationAwareExecutionAction.execute(DefaultTaskExecutionGraph.java:303)
	at org.gradle.execution.plan.DefaultPlanExecutor$ExecutorWorker.execute(DefaultPlanExecutor.java:459)
	at org.gradle.execution.plan.DefaultPlanExecutor$ExecutorWorker.run(DefaultPlanExecutor.java:376)
	at org.gradle.execution.plan.DefaultPlanExecutor.process(DefaultPlanExecutor.java:111)
	at org.gradle.execution.taskgraph.DefaultTaskExecutionGraph.executeWithServices(DefaultTaskExecutionGraph.java:138)
	at org.gradle.execution.taskgraph.DefaultTaskExecutionGraph.execute(DefaultTaskExecutionGraph.java:123)
	at org.gradle.execution.SelectedTaskExecutionAction.execute(SelectedTaskExecutionAction.java:35)
	at org.gradle.execution.DryRunBuildExecutionAction.execute(DryRunBuildExecutionAction.java:51)
	at org.gradle.execution.BuildOperationFiringBuildWorkerExecutor$ExecuteTasks.call(BuildOperationFiringBuildWorkerExecutor.java:54)
	at org.gradle.execution.BuildOperationFiringBuildWorkerExecutor$ExecuteTasks.call(BuildOperationFiringBuildWorkerExecutor.java:43)
	at org.gradle.internal.operations.DefaultBuildOperationRunner$CallableBuildOperationWorker.execute(DefaultBuildOperationRunner.java:209)
	at org.gradle.internal.operations.DefaultBuildOperationRunner$CallableBuildOperationWorker.execute(DefaultBuildOperationRunner.java:204)
	at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:66)
	at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:59)
	at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:166)
	at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:59)
	at org.gradle.internal.operations.DefaultBuildOperationRunner.call(DefaultBuildOperationRunner.java:53)
	at org.gradle.execution.BuildOperationFiringBuildWorkerExecutor.execute(BuildOperationFiringBuildWorkerExecutor.java:40)
	at org.gradle.internal.build.DefaultBuildLifecycleController.lambda$executeTasks$10(DefaultBuildLifecycleController.java:313)
	at org.gradle.internal.model.StateTransitionController.doTransition(StateTransitionController.java:266)
	at org.gradle.internal.model.StateTransitionController.lambda$tryTransition$8(StateTransitionController.java:177)
	at org.gradle.internal.work.DefaultSynchronizer.withLock(DefaultSynchronizer.java:46)
	at org.gradle.internal.model.StateTransitionController.tryTransition(StateTransitionController.java:177)
	at org.gradle.internal.build.DefaultBuildLifecycleController.executeTasks(DefaultBuildLifecycleController.java:304)
	at org.gradle.internal.build.DefaultBuildWorkGraphController$DefaultBuildWorkGraph.runWork(DefaultBuildWorkGraphController.java:220)
	at org.gradle.internal.work.DefaultWorkerLeaseService.withLocks(DefaultWorkerLeaseService.java:263)
	at org.gradle.internal.work.DefaultWorkerLeaseService.runAsWorkerThread(DefaultWorkerLeaseService.java:127)
	at org.gradle.composite.internal.DefaultBuildController.doRun(DefaultBuildController.java:181)
	at org.gradle.composite.internal.DefaultBuildController.access$000(DefaultBuildController.java:50)
	at org.gradle.composite.internal.DefaultBuildController$BuildOpRunnable.lambda$run$0(DefaultBuildController.java:198)
	at org.gradle.internal.operations.CurrentBuildOperationRef.with(CurrentBuildOperationRef.java:85)
	at org.gradle.composite.internal.DefaultBuildController$BuildOpRunnable.run(DefaultBuildController.java:198)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
	at org.gradle.internal.concurrent.ExecutorPolicy$CatchAndRecordFailures.onExecute(ExecutorPolicy.java:64)
	at org.gradle.internal.concurrent.AbstractManagedExecutor$1.run(AbstractManagedExecutor.java:48)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1583)
Caused by: java.nio.file.FileAlreadyExistsException: /Volumes/AstroImageJ/Applications
	at java.base/sun.nio.fs.UnixException.translateToIOException(UnixException.java:94)
	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:106)
	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:111)
	at java.base/sun.nio.fs.UnixFileSystemProvider.createSymbolicLink(UnixFileSystemProvider.java:513)
	at java.base/java.nio.file.Files.createSymbolicLink(Files.java:1069)
	at io.github.fvarrui.javapackager.utils.FileUtils.createSymlink(FileUtils.java:259)
Caused by: java.nio.file.FileAlreadyExistsException: /Volumes/AstroImageJ/Applications

	... 161 more

```
</details>