### PR TITLE
Refactor model for protocol call

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,7 +64,7 @@ dependencies {
 }
 
 group = 'io.github.fvarrui'
-version = '1.7.6'
+version = '1.7.6.1'
 description = 'Hybrid Maven/Gradle plugin to package Java applications as native Windows, Mac OS X or GNU/Linux executables and create installers for them'
 
 sourceCompatibility = JavaVersion.VERSION_1_8

--- a/src/main/java/io/github/fvarrui/javapackager/model/RegistryEntry.java
+++ b/src/main/java/io/github/fvarrui/javapackager/model/RegistryEntry.java
@@ -1,6 +1,9 @@
 package io.github.fvarrui.javapackager.model;
 
+
 import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Windows Registry entry
@@ -9,35 +12,20 @@ public class RegistryEntry implements Serializable {
 	private static final long serialVersionUID = 447936480111873679L;
 
 	/**
-	 * Windows registry key: HKCU, HKLM, ... 
+	 * Windows registry key: HKCU, HKLM, ...
 	 */
 	private String key;
-	
-	/**
-	 * Windows Registry value name
-	 */
-	private String valueName;
-	
-	/**
-	 * Windows Registry value type
-	 */	
-	private ValueType valueType = ValueType.REG_SZ;
-	
-	/**
-	 * Windows Registry value data
-	 */	
-	private String valueData = "";
-	
+
+	private  List<RegistryValue> registryValues = new ArrayList<>();
+
 	public RegistryEntry() {
 		super();
 	}
 
-	public RegistryEntry(String key, String valueName, ValueType valueType, String valueData) {
+	public RegistryEntry(String key, List<RegistryValue> registryValues) {
 		super();
 		this.key = key;
-		this.valueName = valueName;
-		this.valueType = valueType;
-		this.valueData = valueData;
+		this.registryValues = registryValues;
 	}
 
 	public String getKey() {
@@ -48,30 +36,16 @@ public class RegistryEntry implements Serializable {
 		this.key = key;
 	}
 
-	public String getValueName() {
-		return valueName;
+	public List<RegistryValue> getRegistryValues() {
+		return registryValues;
 	}
 
-	public void setValueName(String valueName) {
-		this.valueName = valueName;
+	public void setRegistryValue(List<RegistryValue> registryValues) {
+		this.registryValues = registryValues;
 	}
 
-	public ValueType getValueType() {
-		return valueType;
-	}
 
-	public void setValueType(ValueType valueType) {
-		this.valueType = valueType;
-	}
 
-	public String getValueData() {
-		return valueData;
-	}
-
-	public void setValueData(String valueData) {
-		this.valueData = valueData;
-	}
-	
 	public String getRoot() {
 		return key.split(":")[0];
 	}
@@ -80,44 +54,12 @@ public class RegistryEntry implements Serializable {
 		String subkey = key.split(":")[1];
 		return subkey.startsWith("/") ? subkey.substring(1) : subkey;
 	}
-	
-	/**
-	 * Returns value type as Inno Setup expects
-	 * https://jrsoftware.org/ishelp/index.php?topic=registrysection
-	 * @return Value type converted to IS format
-	 */
-	public String getValueTypeAsInnoSetupString() {
-		switch(valueType) {
-		case REG_BINARY: return "binary";
-		case REG_DWORD: return "dword";
-		case REG_EXPAND_SZ: return "expandsz";
-		case REG_MULTI_SZ: return "multisz";
-		case REG_QWORD: return "qword";
-		case REG_SZ: return "string";
-		default: return "none";
-		}
-	}
 
-	/**
-	 * Returns value type as WIX Toolset expects
-	 * https://wixtoolset.org/documentation/manual/v3/xsd/wix/registryvalue.html
-	 */
-	public String getValueTypeAsWIXToolsetString() {
-		switch(valueType) {
-		case REG_BINARY: return "binary";
-		case REG_DWORD: return "integer";
-		case REG_EXPAND_SZ: return "expandable";
-		case REG_MULTI_SZ: return "multiString";
-		case REG_QWORD: return "integer";
-		case REG_SZ: return "string";
-		default: return "none";
-		}
-	}
+
 
 	@Override
 	public String toString() {
-		return "RegistryEntry [key=" + key + ", valueName=" + valueName + ", valueType=" + valueType + ", valueData="
-				+ valueData + "]";
+		return "RegistryEntry [key=" + key + ", registryValues=" + registryValues + "]";
 	}
 
 }

--- a/src/main/java/io/github/fvarrui/javapackager/model/RegistryValue.java
+++ b/src/main/java/io/github/fvarrui/javapackager/model/RegistryValue.java
@@ -1,0 +1,85 @@
+package io.github.fvarrui.javapackager.model;
+
+import java.io.Serializable;
+
+public class RegistryValue implements Serializable {
+
+    private static final long serialVersionUID = 146958222849019L;
+
+    /**
+     * Windows Registry value name
+     */
+    private String valueName;
+
+    /**
+     * Windows Registry value type
+     */
+    private ValueType valueType = ValueType.REG_SZ;
+
+    /**
+     * Windows Registry value data
+     */
+    private String valueData = "";
+
+    public String getValueName() {
+        return valueName;
+    }
+
+    public void setValueName(String valueName) {
+        this.valueName = valueName;
+    }
+
+    public ValueType getValueType() {
+        return valueType;
+    }
+
+    public void setValueType(ValueType valueType) {
+        this.valueType = valueType;
+    }
+
+    public String getValueData() {
+        return valueData;
+    }
+
+    public void setValueData(String valueData) {
+        this.valueData = valueData;
+    }
+
+    /**
+     * Returns value type as Inno Setup expects
+     * https://jrsoftware.org/ishelp/index.php?topic=registrysection
+     * @return Value type converted to IS format
+     */
+    public String getValueTypeAsInnoSetupString() {
+        switch(valueType) {
+            case REG_BINARY: return "binary";
+            case REG_DWORD: return "dword";
+            case REG_EXPAND_SZ: return "expandsz";
+            case REG_MULTI_SZ: return "multisz";
+            case REG_QWORD: return "qword";
+            case REG_SZ: return "string";
+            default: return "none";
+        }
+    }
+
+    /**
+     * Returns value type as WIX Toolset expects
+     * https://wixtoolset.org/documentation/manual/v3/xsd/wix/registryvalue.html
+     */
+    public String getValueTypeAsWIXToolsetString() {
+        switch(valueType) {
+            case REG_BINARY: return "binary";
+            case REG_DWORD: return "integer";
+            case REG_EXPAND_SZ: return "expandable";
+            case REG_MULTI_SZ: return "multiString";
+            case REG_QWORD: return "integer";
+            case REG_SZ: return "string";
+            default: return "none";
+        }
+    }
+
+    @Override
+    public String toString () {
+        return "RegisterValue [valueName=" + valueName + ",valueType=" + valueType + ",valueData="+valueData+"]";
+    }
+}

--- a/src/main/java/io/github/fvarrui/javapackager/utils/XMLUtils.java
+++ b/src/main/java/io/github/fvarrui/javapackager/utils/XMLUtils.java
@@ -1,6 +1,9 @@
 package io.github.fvarrui.javapackager.utils;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -26,41 +29,54 @@ public class XMLUtils {
 	 * @throws Exception Something went wrong
 	 */
 	public static final void prettify(File file) throws Exception {
+		modifyFile(file,"quotes","&quot;" );
 
 		DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
 		DocumentBuilder builder = factory.newDocumentBuilder();
 		Document document = builder.parse(file);
-		
+
 		trimWhitespace(document);
-		
+
 		Transformer transformer = TransformerFactory.newInstance().newTransformer();
 		transformer.setOutputProperty(OutputKeys.INDENT, "yes");
 		transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "no");
 		transformer.setOutputProperty(OutputKeys.ENCODING, "UTF-8");
 
-        DocumentType doctype = document.getDoctype();
-        if(doctype != null) {
-            transformer.setOutputProperty(OutputKeys.DOCTYPE_PUBLIC, doctype.getPublicId());
-            transformer.setOutputProperty(OutputKeys.DOCTYPE_SYSTEM, doctype.getSystemId());
-        }		
-		
+		DocumentType doctype = document.getDoctype();
+		if(doctype != null) {
+			transformer.setOutputProperty(OutputKeys.DOCTYPE_PUBLIC, doctype.getPublicId());
+			transformer.setOutputProperty(OutputKeys.DOCTYPE_SYSTEM, doctype.getSystemId());
+		}
+
 		transformer.transform(new DOMSource(document), new StreamResult(file));
 
 	}
-	
+
 	/**
 	 * Removes whitespaces from nodes
 	 * @param node Root node
 	 */
 	public static void trimWhitespace(Node node) {
-	    NodeList children = node.getChildNodes();
-	    for(int i = 0; i < children.getLength(); ++i) {
-	        Node child = children.item(i);
-	        if(child.getNodeType() == Node.TEXT_NODE) {
-	            child.setTextContent(child.getTextContent().trim());
-	        }
-	        trimWhitespace(child);
-	    }
+		NodeList children = node.getChildNodes();
+		for(int i = 0; i < children.getLength(); ++i) {
+			Node child = children.item(i);
+			if(child.getNodeType() == Node.TEXT_NODE) {
+				child.setTextContent(child.getTextContent().trim());
+			}
+			trimWhitespace(child);
+		}
+	}
+
+
+	public static void modifyFile(File file, String targetWord, String replacement) throws IOException {
+		// Leer el archivo como String
+		String content = new String(Files.readAllBytes(file.toPath()), StandardCharsets.UTF_8);
+
+		// Reemplazar la palabra
+		content = content.replaceAll(targetWord, replacement);
+
+		// Sobrescribir el archivo con el nuevo contenido
+		Files.write(file.toPath(), content.getBytes(StandardCharsets.UTF_8));
 	}
 
 }

--- a/src/main/resources/windows/msm.wxs.vtl
+++ b/src/main/resources/windows/msm.wxs.vtl
@@ -43,15 +43,12 @@
 			<Component Id="RegistryEntries" Guid="${GUID.randomUUID()}">
 #foreach ($entry in $info.winConfig.registry.entries)
 				<RegistryKey Root="${entry.root}" Key="${entry.subkey}" ForceDeleteOnUninstall="yes">
-					<RegistryValue 
-						Type="${entry.valueTypeAsWIXToolsetString}"
-#if ($entry.valueName)
-						Name="$!{entry.valueName}"
-#end
-#if ($entry.valueData)
-						Value="$!{entry.valueData}"
-#end
+#foreach ($registryValue in $entry.registryValues)
+					<RegistryValue Type="${registryValue.valueTypeAsWIXToolsetString}"
+					#if ($registryValue.valueName) Name="${registryValue.valueName}" #end
+					#if ($registryValue.valueData) Value="${registryValue.valueData}" #else Value=""  #end
 					/>
+#end
 				</RegistryKey>
 #end
 			</Component>


### PR DESCRIPTION
Era necesario modificar el registro para hacer las llamadas por protocolo de desktop desde el navegador a a la aplicación. Esto lleva una configuración especifica en el registro que la antigua versión de javapackager no soportaba (Campos vacíos o con comillas). Con estos cambios se modifica a nivel de pom