### PR TITLE
Fix 463 and rename appimage

### DIFF
--- a/src/main/java/io/github/fvarrui/javapackager/packagers/GenerateAppImage.java
+++ b/src/main/java/io/github/fvarrui/javapackager/packagers/GenerateAppImage.java
@@ -11,9 +11,8 @@ import java.io.File;
 import java.io.IOException;
 
 public class GenerateAppImage extends ArtifactGenerator<LinuxPackager> {
-	
-	private static final int IMAGETOOL_VERSION = 13;
-	private static final String IMAGETOOL_URL = "https://github.com/AppImage/AppImageKit/releases/download/" + IMAGETOOL_VERSION + "/appimagetool-%s.AppImage";
+
+	private static final String IMAGETOOL_URL = "https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-%s.AppImage";
 	
 	public GenerateAppImage() {
 		super("AppImage");

--- a/src/main/java/io/github/fvarrui/javapackager/packagers/GenerateAppImage.java
+++ b/src/main/java/io/github/fvarrui/javapackager/packagers/GenerateAppImage.java
@@ -40,12 +40,13 @@ public class GenerateAppImage extends ArtifactGenerator<LinuxPackager> {
 		File appFolder = packager.getAppFolder();
 		File outputFolder = packager.getOutputDirectory();
 		String name = packager.getName();
+        String version = packager.getVersion();
 		File executable = packager.getExecutable();
 		File assetsFolder = packager.getAssetsFolder();
 		File iconFile = packager.getIconFile();
 
 		// output AppImage file
-		File appImage = new File(outputFolder, name + ".AppImage");
+		File appImage = new File(outputFolder, name + "_" + version + ".AppImage");
 		
 		// AppDir folder
 		File appDir = new File(assetsFolder, "AppDir");

--- a/src/main/java/io/github/fvarrui/javapackager/packagers/GenerateRpm.java
+++ b/src/main/java/io/github/fvarrui/javapackager/packagers/GenerateRpm.java
@@ -93,7 +93,7 @@ public class GenerateRpm extends ArtifactGenerator<LinuxPackager> {
 		builder.build(outputDirectory);
 
 		// renames generated RPM file if created
-		String suffix = "-1." + arch + ".rpm";
+		String suffix = "-1." + getRpmArchString(arch) + ".rpm";
 		File originalRpm = new File(outputDirectory, name + "-" + version + suffix);
 		File rpm = null;
 		if (originalRpm.exists()) {
@@ -128,5 +128,11 @@ public class GenerateRpm extends ArtifactGenerator<LinuxPackager> {
 			}
 		}
 	}
+
+    private String getRpmArchString(Architecture arch) {
+        if (arch == null) return "null";
+
+        return arch.toString().toLowerCase(); // Without Locale to match the redline_rpm way of handling conversion
+    }
 
 }


### PR DESCRIPTION
### Description

This pull request fixes issue #463  by resolving issues related to AppImage and RPM generation for Linux. The problems were due to:

- An outdated download link for AppImageKit  
- A mismatch between the expected and actual RPM filename

Additionally, the AppImage filename has been updated from `${name}.AppImage` to `${name}_${version}.AppImage` to align with the naming conventions and documentation in the README.

### Changes

- Fixed logic in `GenerateRpm.java` and `GenerateAppImage.java` to address issue #463  
- Renamed AppImage output to `${name}_${version}.AppImage` for consistency with the README and other artifacts

### Testing

- Manually verified that RPM and AppImage files are now generated correctly  
- Confirmed that the renamed AppImage builds and runs as expected